### PR TITLE
bflibrary: Fix assignment instead of comparison in LbRegisterVideoModeString

### DIFF
--- a/bflibrary/src/general/gscreen.c
+++ b/bflibrary/src/general/gscreen.c
@@ -161,7 +161,7 @@ TbScreenMode LbRegisterVideoModeString(const char *desc)
     if (bpp < 9) {
         flags |= Lb_VF_PALETTE;
     } else
-    if ((bpp == 24) || (bpp = 32)) {
+    if ((bpp == 24) || (bpp == 32)) {
         flags |= Lb_VF_RGBCOLOUR;
     } else
     {


### PR DESCRIPTION
`LbRegisterVideoModeString()` tested the bits-per-pixel value with `=` rather
than `==` in the second half of the condition:

```c
if ((bpp == 24) || (bpp = 32)) {
```

Two consequences. The condition is true for every `bpp >= 9`, so the
`Lb_VF_HICOLOUR` branch below it is unreachable. And the assignment overwrites
`bpp`, so a mode described as 16-bit is registered as a 32-bit one.

Fixes #409.

Note: `swfans/syndicatfx` carries the same file with the same defect at the
same line, in case you want it tracked there too.
