### PR TITLE
swrendersoft: Fix inline asm constraints in mul_shift16_sign_pad_lo

### DIFF
--- a/swrendersoft/src/engintrns.c
+++ b/swrendersoft/src/engintrns.c
@@ -56,12 +56,16 @@ s32 mul_shift16_sign_pad_lo(s32 ar1, s32 ar2)
     tmp |= ((ar1 * (s64)ar2) >> 32) & 0xFFFF;
     return bw_rotl32(tmp, 16);
 #else
-    s32 ret;
+    s32 ret, hi;
+    /* The asm overwrites both eax and edx, so both have to be outputs with the
+     * inputs tied to them; declaring them as inputs only lets the compiler
+     * assume they still hold ar1 and ar2 afterwards. Harmless at -O0, wrong
+     * at any higher optimisation level. */
     asm volatile (
       "imul   %%edx\n"
       "mov    %%dx,%%ax\n"
       "rol    $0x10,%%eax\n"
-        : "=r" (ret) : "a" (ar1), "d" (ar2));
+        : "=a" (ret), "=d" (hi) : "0" (ar1), "1" (ar2) : "cc");
     return ret;
 #endif
 }


### PR DESCRIPTION
`mul_shift16_sign_pad_lo()` in `swrendersoft/src/engintrns.c` contains an inline
asm block whose operand constraints do not describe what it actually does:

```c
    asm volatile (
      "imul   %%edx\n"
      "mov    %%dx,%%ax\n"
      "rol    $0x10,%%eax\n"
        : "=r" (ret) : "a" (ar1), "d" (ar2));
```

`imul %edx` writes both `%eax` and `%edx`, and after the `rol` the result sits
in `%eax`. Yet `%eax` and `%edx` are declared as inputs only, and the output is
an unconstrained `"=r"`. The compiler is therefore free to assume both registers
still hold `ar1` and `ar2` after the block, and to read the result from a
register that was never written.

This does not misbehave today because the project is built without
optimisation, where every value is reloaded from the stack after each
statement. That is easy to miss: the build lines in `README.md` and in
`.github/workflows/build.yaml` set `CFLAGS` explicitly, which suppresses the
`-g -O2` that `AC_PROG_CC` would otherwise add, so `-O0` is what everyone gets.
The bug only becomes reachable once that changes.

The fix makes `%eax` the output, `%edx` an in-out operand, and declares the
condition codes clobbered. There is no cost: at `-O2 -m32` the function still
compiles to loading the arguments into `%eax` and `%edx`, the asm block, and a
return, since the result is already in the right register.

Found while investigating renderer performance at 2560x1440 on Linux Mint 22.3
(32-bit build, SDL2).
