### PR TITLE
syndwarsfx: Add [atmospheric] rules for the sizes of weather effects

### DIFF
--- a/conf/rules.ini
+++ b/conf/rules.ini
@@ -10,6 +10,17 @@ ZoomMin = 145
 ; Value must not be lower than ZoomMin.
 ZoomMax = 263
 
+[atmospheric]
+; Widest a rain drop may get, in pixels. The drop is sized from the screen
+; height, so what was a one pixel streak on the original display becomes a
+; five pixel bar at 1080 lines. 0 keeps that scaling, as it has always been.
+RainDropMaxWidth = 0
+; Largest a snow flake may get, in pixels. Sized the same way as the rain
+; drop above. 0 keeps the scaling.
+SnowFlakeMaxSize = 0
+; Largest a background star may get, in pixels. 0 keeps the scaling.
+StarMaxSize = 0
+
 [scanner]
 ; Factor of how much map area fits on the ingame scanner map.
 ; Valid values ranged 16..512, where 512 would make the whole map visible.

--- a/src/rules.c
+++ b/src/rules.c
@@ -22,6 +22,7 @@
 #include "bfini.h"
 #include "bfmemory.h"
 
+#include "enginpeff.h"
 #include "enginzoom.h"
 #include "game_data.h"
 #include "hud_target.h"
@@ -75,6 +76,12 @@ enum RulesRevenueConfigCmd {
     RRevenuCmd_PersuadedPersonWeaponsSellCostPermil = 1,
 };
 
+enum RulesAtmosphericConfigCmd {
+    RAtmosCmd_RainDropMaxWidth = 1,
+    RAtmosCmd_SnowFlakeMaxSize,
+    RAtmosCmd_StarMaxSize,
+};
+
 const struct TbNamedEnum rules_conf_research_cmnds[] = {
   {"DailyScientistDeathChancePermil",	RResrchCmd_DailyScientistDeathChance},
   {"ScientistsPerGroup",			RResrchCmd_ScientistsPerGroup},
@@ -85,6 +92,13 @@ const struct TbNamedEnum rules_conf_research_cmnds[] = {
 
 const struct TbNamedEnum rules_conf_revenue_cmnds[] = {
   {"PersuadedPersonWeaponsSellCostPermil",	RRevenuCmd_PersuadedPersonWeaponsSellCostPermil},
+  {NULL,							0},
+};
+
+const struct TbNamedEnum rules_conf_atmospheric_cmnds[] = {
+  {"RainDropMaxWidth",				RAtmosCmd_RainDropMaxWidth},
+  {"SnowFlakeMaxSize",				RAtmosCmd_SnowFlakeMaxSize},
+  {"StarMaxSize",					RAtmosCmd_StarMaxSize},
   {NULL,							0},
 };
 
@@ -370,6 +384,64 @@ TbBool read_rules_file(void)
             }
             persuaded_person_weapons_sell_cost_permil = k;
             CONFDBGLOG("%s %d", COMMAND_TEXT(cmd_num), (int)persuaded_person_weapons_sell_cost_permil);
+            break;
+        case 0: // comment
+            break;
+        case -1: // end of buffer
+        case -3: // end of section
+            done = true;
+            break;
+        default:
+            CONFWRNLOG("Unrecognized command.");
+            break;
+        }
+        LbIniSkipToNextLine(&parser);
+    }
+#undef COMMAND_TEXT
+
+    // Parse the [atmospheric] section of loaded file
+    done = false;
+    if (LbIniFindSection(&parser, "atmospheric") != Lb_SUCCESS) {
+        CONFWRNLOG("Could not find \"[%s]\" section.", "atmospheric");
+        done = true;
+    }
+#define COMMAND_TEXT(cmd_num) LbNamedEnumGetName(rules_conf_atmospheric_cmnds,cmd_num)
+    while (!done)
+    {
+        int cmd_num;
+
+        // Finding command number in this line
+        i = 0;
+        cmd_num = LbIniRecognizeKey(&parser, rules_conf_atmospheric_cmnds);
+        // Now store the config item in correct place
+        switch (cmd_num)
+        {
+        case RAtmosCmd_RainDropMaxWidth:
+            i = LbIniValueGetLongInt(&parser, &k);
+            if (i <= 0) {
+                CONFWRNLOG("Could not read \"%s\" command parameter.", COMMAND_TEXT(cmd_num));
+                break;
+            }
+            rain_drop_max_width = k;
+            CONFDBGLOG("%s %d", COMMAND_TEXT(cmd_num), (int)rain_drop_max_width);
+            break;
+        case RAtmosCmd_SnowFlakeMaxSize:
+            i = LbIniValueGetLongInt(&parser, &k);
+            if (i <= 0) {
+                CONFWRNLOG("Could not read \"%s\" command parameter.", COMMAND_TEXT(cmd_num));
+                break;
+            }
+            snow_flake_max_size = k;
+            CONFDBGLOG("%s %d", COMMAND_TEXT(cmd_num), (int)snow_flake_max_size);
+            break;
+        case RAtmosCmd_StarMaxSize:
+            i = LbIniValueGetLongInt(&parser, &k);
+            if (i <= 0) {
+                CONFWRNLOG("Could not read \"%s\" command parameter.", COMMAND_TEXT(cmd_num));
+                break;
+            }
+            star_max_size = k;
+            CONFDBGLOG("%s %d", COMMAND_TEXT(cmd_num), (int)star_max_size);
             break;
         case 0: // comment
             break;

--- a/swrendersoft/include/enginpeff.h
+++ b/swrendersoft/include/enginpeff.h
@@ -39,6 +39,23 @@ enum GamePostSceneEffectType {
 extern ushort gamep_scene_effect_type;
 extern ushort gamep_scene_effect_intensity;
 
+/** Widest a rain drop may be drawn, in pixels; 0 means no limit.
+ *
+ * The drop is sized from the screen height, so the one pixel streak of the
+ * original display becomes a wide bar on a modern one. Only the width is
+ * capped; the length still follows the resolution.
+ */
+extern ushort rain_drop_max_width;
+
+/** Largest a snow flake may be drawn, in pixels; 0 means no limit.
+ *
+ * The flake is a square sized the same way as the rain drop above.
+ */
+extern ushort snow_flake_max_size;
+
+/** Largest a background star may be drawn, in pixels; 0 means no limit. */
+extern ushort star_max_size;
+
 /* Wavy float table with even number of elements.
  *
  * The period of this table is 31, last element repeats first.

--- a/swrendersoft/src/enginpeff.c
+++ b/swrendersoft/src/enginpeff.c
@@ -46,6 +46,18 @@ ushort gamep_scene_effect_intensity = 1000;
 short gamep_scene_effect_change = -1;
 ushort gamep_scene_effect_type = ScEff_NONE;
 
+ushort rain_drop_max_width = 0;
+ushort snow_flake_max_size = 0;
+ushort star_max_size = 0;
+
+/** Applies one of the effect size limits, a limit of zero meaning none. */
+static ushort size_limited(ushort size, ushort limit)
+{
+    if ((limit != 0) && (size > limit))
+        return limit;
+    return size;
+}
+
 ushort word_1A7314;
 ushort word_1A7330[1000];
 ubyte byte_1A7B00[1000];
@@ -210,7 +222,7 @@ void draw_falling_rain(int bckt)
     y = m * ((rnd + (shift_y >> 10)) % limit_y);
     lbDisplay.DrawFlags = Lb_SPRITE_TRANSPAR4;
     o = &lbDisplay.WScreen[scanln * y + x];
-    w = m;
+    w = size_limited(m, rain_drop_max_width);
     h = m;
     if (bckt < 4000) h += m;
     if (bckt < 3000) h += m;
@@ -252,6 +264,7 @@ void draw_falling_snow(int bckt)
         uint x, y;
         ushort speed;
         ushort angXZs, angXZc;
+        ushort dm;
 
         angXZs = ((engn_anglexz >> 5)) & 0x7FF;
         angXZc = ((engn_anglexz >> 5) + LbFPMath_PI/2) & 0x7FF;
@@ -264,7 +277,8 @@ void draw_falling_snow(int bckt)
         shift2 = (BUCKETS_COUNT - bckt) * render_anim_turn;
         y = (shift2 >> (12 - speed/2)) + ((engn_xc * lbSinTable[angXZs]) >> 20) + ((engn_zc * lbSinTable[angXZc]) >> 20) + LbRandomAnyShort();
         lbDisplay.DrawFlags = Lb_SPRITE_TRANSPAR4;
-        draw_static_dot((x * m) % scanln, (y % height) * m, m, m, 128 * ((BUCKETS_COUNT - bckt) / 416) + colour_lookup[ColLU_WHITE]);
+        dm = size_limited(m, snow_flake_max_size);
+        draw_static_dot((x * m) % scanln, (y % height) * m, dm, dm, 128 * ((BUCKETS_COUNT - bckt) / 416) + colour_lookup[ColLU_WHITE]);
         lbSeed = seed_bkp;
         lbDisplay.DrawFlags = 0;
     }
@@ -310,10 +324,11 @@ void draw_background_stars(void)
     ulong seed_bkp;
     int i, limit;
     int scr_x0, scr_y0;
-    ushort m;
+    ushort m, dm;
 
     m = lbDisplay.GraphicsScreenHeight / 300;
     if (m == 0) m++;
+    dm = size_limited(m, star_max_size);
     scr_x0 = lbDisplay.GraphicsScreenWidth / 2;
     scr_y0 = lbDisplay.GraphicsScreenHeight / 2;
 
@@ -340,7 +355,7 @@ void draw_background_stars(void)
         scr_x = scr_x0 + ((simp_x * m * dword_176D14 - simp_y * m * dword_176D10) >> 16);
         scr_y = scr_y0 - ((simp_x * m * dword_176D10 + simp_y * m * dword_176D14) >> 16);
 
-        draw_distant_stars(scr_x, scr_y, m, m, 79 - (plane >> 1));
+        draw_distant_stars(scr_x, scr_y, dm, dm, 79 - (plane >> 1));
     }
     lbSeed = seed_bkp;
 }


### PR DESCRIPTION
The rain drop, the snow flake and the background star are each sized from the screen height, so what was a one pixel mark on the display the game was drawn for becomes a block on a modern one. At 1080 lines a drop is five pixels across, and the rain reads as falling bars.

Following the discussion below, this replaces the fixed one pixel width of the first version with a limit per effect, read from a new `[atmospheric]` section of `rules.ini`:

```
[atmospheric]
RainDropMaxWidth = 0
SnowFlakeMaxSize = 0
StarMaxSize = 0
```

Zero means no limit, so nothing changes for anyone who leaves the file alone, and a different default stays a one line change.

Only the size is capped. The length of the drop, the drift of the flakes and the depth of the stars keep following the resolution.
