### PR TITLE
bflibrary: Write pixel spans as a plain loop so it can be unrolled

### DIFF
--- a/bflibrary/src/general/poly_gp.c
+++ b/bflibrary/src/general/poly_gp.c
@@ -26,8 +26,6 @@
 #include "poly_trigp.h"
 #include "privbflog.h"
 
-const long gpoly_countdown[] = { 0,-15,-14,-13,-12,-11,-10, -9,  -8, -7, -6, -5, -4, -3, -2, -1 };
-
 const long gpoly_reptable[] = {
          0x0,0x7FFFFFFF,0x3FFFFFFF,0x2AAAAAAA,0x1FFFFFFF,0x19999999,0x15555555,0x12492492,
   0x0FFFFFFF,0x0E38E38E,0x0CCCCCCC,0x0BA2E8BA,0x0AAAAAAA, 0x9D89D89, 0x9249249, 0x8888888,
@@ -1073,26 +1071,17 @@ void gpoly_rasterize_shaded_bound(struct gpoly_state *st)
             if (range_len > 0)
             {
                 ubyte *o;
-                int kk_max;
 
-                kk_max = range_len & 0xF;
-                o = &loc_0F4[curr_X + gpoly_countdown[kk_max]];
+                // Writes range_len consecutive pixels. This used to be a
+                // variable trip count loop entered at an offset through
+                // gpoly_countdown[], which no compiler can unroll.
+                o = &loc_0F4[curr_X];
                 range_remain = range_len;
-                while ( 1 )
+                while (range_remain > 0)
                 {
-                    int kk;
-
-                    for (kk = kk_max; kk > 0; kk--) {
-                        o[16-kk] = gpoly_pixel_shaded(&bld, &st->incB);
-                    }
-                    if (kk_max != 0) {
-                        o += 16;
-                        range_remain -= 16;
-                        if (range_remain <= 0)
-                            break;
-                    }
-                    o[0] = gpoly_pixel_shaded(&bld, &st->incB);
-                    kk_max = 15;
+                    *o = gpoly_pixel_shaded(&bld, &st->incB);
+                    o++;
+                    range_remain--;
                 }
             }
             range_end = loc_128 + loc_0F8;
@@ -1217,26 +1206,17 @@ void gpoly_rasterize_shaded_nobound(struct gpoly_state *st)
             if (range_len > 0)
             {
                 ubyte *o;
-                int kk_max;
 
-                kk_max = range_len & 0xF;
-                o = &loc_0F4[range_beg_scr + gpoly_countdown[kk_max]];
+                // Writes range_len consecutive pixels. This used to be a
+                // variable trip count loop entered at an offset through
+                // gpoly_countdown[], which no compiler can unroll.
+                o = &loc_0F4[range_beg_scr];
                 range_remain = range_len;
-                while ( 1 )
+                while (range_remain > 0)
                 {
-                    int kk;
-
-                    for (kk = kk_max; kk > 0; kk--) {
-                        o[16-kk] = gpoly_pixel_shaded(&bld, &st->incB);
-                    }
-                    if (kk_max != 0) {
-                        o += 16;
-                        range_remain -= 16;
-                        if (range_remain <= 0)
-                            break;
-                    }
-                    o[0] = gpoly_pixel_shaded(&bld, &st->incB);
-                    kk_max = 15;
+                    *o = gpoly_pixel_shaded(&bld, &st->incB);
+                    o++;
+                    range_remain--;
                 }
             }
             range_beg = loc_12C + loc_0FC;
@@ -1372,27 +1352,16 @@ void gpoly_rasterize_noshade_bound(struct gpoly_state *st)
             range_len = range_end_scr - curr_X;
             if (range_len > 0)
             {
-                int kk_max;
-
-                kk_max = range_len & 0xF;
-                o = &loc_0F4[curr_X + gpoly_countdown[kk_max]];
+                // Writes range_len consecutive pixels. This used to be a
+                // variable trip count loop entered at an offset through
+                // gpoly_countdown[], which no compiler can unroll.
+                o = &loc_0F4[curr_X];
                 range_remain = range_len;
-
-                while ( 1 )
+                while (range_remain > 0)
                 {
-                    int kk;
-
-                    for (kk = kk_max; kk > 0; kk--) {
-                        o[16-kk] = gpoly_pixel_noshade(&bld, &st->incB);
-                    }
-                    if (kk_max != 0) {
-                        o += 16;
-                        range_remain -= 16;
-                        if (range_remain <= 0)
-                            break;
-                    }
-                    o[0] = gpoly_pixel_noshade(&bld, &st->incB);
-                    kk_max = 15;
+                    *o = gpoly_pixel_noshade(&bld, &st->incB);
+                    o++;
+                    range_remain--;
                 }
             }
             range_beg = loc_12C + loc_0FC;
@@ -1519,27 +1488,16 @@ void gpoly_rasterize_noshade_nobound(struct gpoly_state *st)
             range_len = range_end_scr - curr_X;
             if (range_len > 0)
             {
-                int kk_max;
-
-                kk_max = range_len & 0xF;
-                o = &loc_0F4[curr_X + gpoly_countdown[kk_max]];
+                // Writes range_len consecutive pixels. This used to be a
+                // variable trip count loop entered at an offset through
+                // gpoly_countdown[], which no compiler can unroll.
+                o = &loc_0F4[curr_X];
                 range_remain = range_len;
-
-                while ( 1 )
+                while (range_remain > 0)
                 {
-                    int kk;
-
-                    for (kk = kk_max; kk > 0; kk--) {
-                        o[16-kk] = gpoly_pixel_noshade(&bld, &st->incB);
-                    }
-                    if (kk_max != 0) {
-                        o += 16;
-                        range_remain -= 16;
-                        if (range_remain <= 0)
-                            break;
-                    }
-                    o[0] = gpoly_pixel_noshade(&bld, &st->incB);
-                    kk_max = 15;
+                    *o = gpoly_pixel_noshade(&bld, &st->incB);
+                    o++;
+                    range_remain--;
                 }
             }
             range_beg = loc_12C + loc_0FC;


### PR DESCRIPTION
Following on from #416.

The four `gpoly_rasterize_*` functions fill a pixel span through a variable trip count loop entered at an offset taken from `gpoly_countdown[]`, which looks like a transcription of the sixteen times unrolled block the original assembly used. I simulated it for every length from 0 to 199: it amounts to writing `range_len` consecutive pixels in order, nothing more.

Written that way it is shorter, and unlike the original shape it is something a compiler can unroll when asked to. On the same route at 1920x1080, the renderer sustains 55 frames a second as it stands, 58 with this change alone, and 69 with `unroll-loops` requested for the file. The seven bflibrary tests pass in all three builds.

`gpoly_countdown[]` has no remaining use and goes with it.

I measured on `gpoly_rasterize_shaded_nobound`, which is where the profile time goes. The other three carry the same code and I changed them for consistency, but I have no separate figures for them.
