### PR TITLE
Read the shifted key table through its own symbol

### DIFF
--- a/src/swars.sx
+++ b/src/swars.sx
@@ -32,6 +32,7 @@
 .text
 
 .global EXPORT_SYMBOL(lbInkeyToAscii);
+.global EXPORT_SYMBOL(lbInkeyToAsciiShift);
 .global EXPORT_SYMBOL(lbInkey_prefixed);
 .global EXPORT_SYMBOL(lbInkey);
 .global EXPORT_SYMBOL(lbShift);
@@ -8950,7 +8951,7 @@ GLOBAL_FUNC (ASM_player_chat_message_add_key)	/* 0x3E580 */
 		test   %edi,%edi
 		je     jump_3e674
 		xor    %ecx,%eax
-		mov    EXPORT_SYMBOL(lbInkeyToAscii)+128(%edx),%al
+		mov    EXPORT_SYMBOL(lbInkeyToAsciiShift)(%edx),%al
 		jmp    jump_3e67c
 	jump_3e674:
 		xor    %ecx,%eax
@@ -131120,7 +131121,7 @@ GLOBAL_FUNC(ASM_user_read_value)	/* 0x0D0380 */
 		testb  $0x1,EXPORT_SYMBOL(lbShift)
 		je     jump_d049f
 	jump_d0499:
-		mov    EXPORT_SYMBOL(lbInkeyToAscii)+128(%esi),%al
+		mov    EXPORT_SYMBOL(lbInkeyToAsciiShift)(%esi),%al
 	jump_d049f:
 		mov    %al,0xc(%esp)
 	jump_d04a3:


### PR DESCRIPTION
While trying to find out why building `bflibrary` with `-O2` leaves the game
without usable keyboard input (#413), I ended up somewhere I did not expect:
the library looks fine, and the assumption which breaks is in the assembly.

`ASM_user_read_value()` and `ASM_player_chat_message_add_key()` reach the
shifted character table as `lbInkeyToAscii+128`:

```asm
mov    EXPORT_SYMBOL(lbInkeyToAscii)+128(%esi),%al
```

`lbInkeyToAscii[]` and `lbInkeyToAsciiShift[]` are two separate 128 byte
arrays in `bflibrary/src/general/gkeybd.c`, so that offset only lands on the
second one while the compiler happens to emit them in that order. `nm -S` on
`gkeybd.o`:

| | `lbInkeyToAscii` | `lbInkeyToAsciiShift` |
|---|---|---|
| `-O0` | 0x00 | 0x80 |
| `-O2` | 0xa0 | 0x20 |

At `-O2` the shifted table comes out 128 bytes *before* the other one, and
the read lands on unrelated data. What that looks like in play is that
typing a name in the login screen mostly does nothing: the character which
comes back is usually rejected a few instructions later by the font width
check at `jump_d04a3`, and the ones which get through are wrong - pressing
`j` gave me `>` in one build. It moves around between builds, which is part
of why it looked so odd.

The patch points both instructions at the `lbInkeyToAsciiShift` symbol,
which should be right whatever the layout turns out to be.

Checked with `objdump -r` plus the addend stored in `.text`: the two
relocations go from `lbInkeyToAscii+128` to `lbInkeyToAsciiShift+0`, and
nothing else in the file moves.

Tested on Linux Mint 22.3, 32 bit build, SDL2:

- default build - login name, save slot name and in-mission keys all behave
  as they did before the change;
- with `make -C bflibrary CPPFLAGS="-O2 -fno-strict-aliasing"` - same,
  where before the login screen would not take a name at all.

The second site is the network chat, which I have not been able to exercise
here, so that one rests on the change being the same in kind rather than on
a test.

I also had a look at the other `EXPORT_SYMBOL(x)+N` accesses in the
assembly, in case the same assumption shows up elsewhere: `lbDisplay+N`,
`lbKeyOn+N` and `lbSinTable+N` all stay within a single struct or array.
These two appear to be the only ones reaching from one object into another,
though I would not claim the search was exhaustive.

On #413: this removes the one concrete blocker I knew of for building
`bflibrary` with optimisations. I do not think it proves anything beyond
that.
