### PR TITLE
Sleep out the tail of a wait instead of spinning on the clock

### DIFF
--- a/bflibrary/configure.ac
+++ b/bflibrary/configure.ac
@@ -80,6 +80,14 @@ AC_ARG_WITH([lb-memory-low-available],
 AC_DEFINE_UNQUOTED([MEMORY_LOW_AVAILABLE], [$lb_memory_low_available],
     [Set to amount of memory available for allocations in below 1MB arena, in kilobytes; only used in memory arenas mode])
 
+AC_ARG_WITH([lb-large-delay-time],
+    [AS_HELP_STRING([--with-lb-large-delay-time=N],
+        [set the sleep period used while waiting for time to pass to N milliseconds (default: 20)])],
+    [lb_large_delay_time="$withval"], [lb_large_delay_time=20])
+
+AC_DEFINE_UNQUOTED([LARGE_DELAY_TIME], [$lb_large_delay_time],
+    [Set to the length of the sleep period used while waiting for time to pass, in milliseconds])
+
 AC_ARG_ENABLE([lb-mouse-wheel],
     AS_HELP_STRING([--disable-lb-mouse-wheel],
         [make the bflibrary to not define mouse wheel properties within lbDisplay]),

--- a/bflibrary/include/bfwindows.h
+++ b/bflibrary/include/bfwindows.h
@@ -26,7 +26,6 @@
 extern "C" {
 #endif
 
-#define LB_LARGE_DELAY_TIME 20
 #define LB_IDLE_HANDLERS_MAX 4
 
 typedef TbBool (*TbIdleControl)(void);

--- a/bflibrary/src/x86-win-sdl/stime.c
+++ b/bflibrary/src/x86-win-sdl/stime.c
@@ -18,6 +18,7 @@
  */
 /******************************************************************************/
 #include <time.h>
+#include <SDL.h>
 #include "bftime.h"
 
 #include "bfwindows.h"
@@ -78,6 +79,15 @@ TbClockMSec LbTimerClock(void)
 #endif
 }
 
+/** @internal
+ * Sleeps for the given amount of milliseconds.
+ */
+static void LbI_SleepShort(TbClockMSec delay)
+{
+    if (delay > 0)
+        SDL_Delay(delay);
+}
+
 TbBool LbSleepUntil(TbClockMSec endtime)
 {
     TbClockMSec currclk;
@@ -87,8 +97,8 @@ TbBool LbSleepUntil(TbClockMSec endtime)
         LbDoMultitasking();
         currclk = LbTimerClock();
     }
-    while (currclk < endtime)
-        currclk = LbTimerClock();
+    if (currclk < endtime)
+        LbI_SleepShort(endtime - currclk);
     return true;
 }
 

--- a/bflibrary/src/x86-win-sdl2/stime.c
+++ b/bflibrary/src/x86-win-sdl2/stime.c
@@ -18,6 +18,7 @@
  */
 /******************************************************************************/
 #include <time.h>
+#include <SDL.h>
 #include "bftime.h"
 
 #include "bfwindows.h"
@@ -78,6 +79,15 @@ TbClockMSec LbTimerClock(void)
 #endif
 }
 
+/** @internal
+ * Sleeps for the given amount of milliseconds.
+ */
+static void LbI_SleepShort(TbClockMSec delay)
+{
+    if (delay > 0)
+        SDL_Delay(delay);
+}
+
 TbBool LbSleepUntil(TbClockMSec endtime)
 {
     TbClockMSec currclk;
@@ -87,8 +97,8 @@ TbBool LbSleepUntil(TbClockMSec endtime)
         LbDoMultitasking();
         currclk = LbTimerClock();
     }
-    while (currclk < endtime)
-        currclk = LbTimerClock();
+    if (currclk < endtime)
+        LbI_SleepShort(endtime - currclk);
     return true;
 }
 


### PR DESCRIPTION
This follows your reply on #414. Two commits, so you can take one without
the other.

**Sleeping out the tail of a wait.** `LbSleepShort()` sits next to
`LbDoMultitasking()` in both SDL backends, as a thin wrapper over the
platform sleep, and `LbSleepUntil()` uses it for the part of the wait that
used to be a plain loop on the clock. The idle loop which calls
`LbDoMultitasking()` every `LB_LARGE_DELAY_TIME` is left exactly as it was,
since you did not want the event pumping period to change.

**The period as a configure option.** `--with-lb-large-delay-time=N`,
defaulting to 20, built the same way as `--with-lb-memory-available`. The
`#define` in `bfwindows.h` becomes a fallback for builds made without the
configure script, so nothing changes unless the option is passed.

One side effect worth pointing out: declaring `LbSleepShort()` in
`bfwindows.h` means that header now includes `bftime.h`, for `TbClockMSec`.
I could move the declaration to `bftime.h` instead if you would rather keep
`bfwindows.h` as it is - it just seemed to belong next to
`LbDoMultitasking()`, as you suggested.

Measured here on Linux Mint 22.3, 32 bit build, SDL2, at 2560x1440, sitting
still in a mission, sampling `/proc/<pid>/stat` over 15 seconds:

| | CPU |
|---|---|
| before | 67 % |
| after | 50 % |

That is with `bflibrary` built at `-O2`; at `-O0` the machine has no slack
left in a game turn, so there is nothing to give back and the change makes
no measurable difference. The 17 point drop lines up with an earlier profile
of the same machine, where a turn took about 49 ms out of the 62 ms budget -
roughly a fifth of the budget being spent asking for the time. I would not
read those numbers as anything more than one machine at one resolution.

I could not see any change in how the game runs, including on a deliberately
heavy level. The one thing I am aware of is that `SDL_Delay()` may overshoot
by a millisecond or so where the old loop stopped exactly on time; nothing
of that was visible here, but you may have platforms in mind where it
matters more.

The `x86-dos-watcom` backend defines neither `LbSleepUntil()` nor
`LbDoMultitasking()`, so there was nothing to do there. The WIN32 branch of
`LbSleepShort()` follows the existing code in `LbDoMultitasking()` but I have
no way to test it here.
