### PR TITLE
Draw several frames per game turn

### DIFF
--- a/src/engindrwlstm_wrp.c
+++ b/src/engindrwlstm_wrp.c
@@ -241,7 +241,7 @@ void draw_pers_e_graphic(struct Thing *p_thing,
     br_inc = person_shield_glow_brightness(p_thing);
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[render_anim_turn & 0x1F] >> 3;
+        cor_dy += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, cor_dx, 8 * cor_dy - 8 * engn_yc, cor_dz);
 
@@ -769,7 +769,7 @@ int draw_rot_object(int cor_dx, int cor_dy, int cor_dz,
     assert((p_thing->U.UObject.MatrixIndex < next_local_mat) || (p_thing->Type == TT_ROCKET));
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[render_anim_turn & 0x1F];
+        cor_dy += waft_between_turns(render_anim_turn);
 
     object_points_clear_flags(point_object);
 
@@ -828,7 +828,7 @@ short draw_object_faces(int cor_dx, int cor_dy, int cor_dz,
     depth_shift = point_object->field_1E;
 
     if ((point_object->field_1C & 0x0100) != 0 && ((doflags & DrwObjF_NoWobblyElevation) == 0))
-        cor_dy += waft_table[render_anim_turn & 0x1F];
+        cor_dy += waft_between_turns(render_anim_turn);
 
     bckt_max = 0;
 

--- a/src/game.c
+++ b/src/game.c
@@ -1719,11 +1719,313 @@ void screen_sorted_sprite_persn_render_callback(ushort sspr)
     }
 }
 
-void process_engine_unk3(void)
+/******************************************************************************/
+/* Drawing several frames within one game turn.
+ *
+ * The simulation still advances once per game turn. The extra frames drawn in
+ * between differ only by the camera position, which is moved along the path
+ * the camera travelled during the previous turn. This costs one turn worth of
+ * camera latency, and makes map scrolling smooth.
+ */
+
+static s32 cam_frm_prev_x, cam_frm_prev_z, cam_frm_prev_angle;
+static s32 cam_frm_curr_x, cam_frm_curr_z, cam_frm_curr_angle;
+static s32 cam_frm_save_x, cam_frm_save_z, cam_frm_save_angle;
+
+/** Distance above which a camera move is considered a jump rather than a
+ * scroll, and is therefore not interpolated. Two map tiles. */
+#define CAM_FRM_JUMP_DIST 512
+
+/** A full camera turn, in the units engn_anglexz is kept in. Readers shift it
+ * right by 5 before masking with LbFPMath_AngleMask. */
+#define CAM_FRM_ANGLE_FULL ((LbFPMath_AngleMask + 1) << 5)
+
+/** Records where the camera ended up for the turn whose input was just
+ * processed. To be called once per game turn, right after input(). */
+static void camera_turn_recorded(void)
+{
+    cam_frm_prev_x = cam_frm_curr_x;
+    cam_frm_prev_z = cam_frm_curr_z;
+    cam_frm_prev_angle = cam_frm_curr_angle;
+    cam_frm_curr_x = engn_xc;
+    cam_frm_curr_z = engn_zc;
+    cam_frm_curr_angle = engn_anglexz;
+}
+
+/** Moves the camera to where it should be for the given frame of the current
+ * turn, keeping the real position aside. Frames are numbered from 0, and the
+ * last one lands exactly on the real position. */
+static void camera_frame_begin(ushort frame)
+{
+    s32 dx, dz, dangle;
+
+    cam_frm_save_x = engn_xc;
+    cam_frm_save_z = engn_zc;
+    cam_frm_save_angle = engn_anglexz;
+
+    if (render_frames_this_turn <= 1)
+        return;
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+
+    dx = cam_frm_curr_x - cam_frm_prev_x;
+    dz = cam_frm_curr_z - cam_frm_prev_z;
+    // A jump rather than a scroll - snap instead of sliding across the map.
+    // Checked on its own, so that a camera teleport does not also freeze the
+    // rotation for that turn.
+    if ((abs(dx) <= CAM_FRM_JUMP_DIST) && (abs(dz) <= CAM_FRM_JUMP_DIST))
+    {
+        engn_xc = cam_frm_prev_x + dx * (frame + 1) / render_frames_this_turn;
+        engn_zc = cam_frm_prev_z + dz * (frame + 1) / render_frames_this_turn;
+    }
+
+    // engn_anglexz is a free running accumulator, never masked anywhere in the
+    // tree; readers take (engn_anglexz >> 5) & LbFPMath_AngleMask, so a full
+    // turn is CAM_FRM_ANGLE_FULL and not LbFPMath_AngleMask + 1. Masking it
+    // here used to squeeze the camera into a thirty-second of a turn, which
+    // froze byte_176D49 and with it the facing of every person sprite.
+    dangle = cam_frm_curr_angle - cam_frm_prev_angle;
+    if (labs(dangle) < CAM_FRM_ANGLE_FULL / 2)
+    {
+        engn_anglexz = cam_frm_prev_angle
+          + dangle * (frame + 1) / render_frames_this_turn;
+        camera_update_angle_derived();
+    }
+}
+
+/** Puts the real camera position back after a frame has been drawn. */
+static void camera_frame_end(void)
+{
+    engn_xc = cam_frm_save_x;
+    engn_zc = cam_frm_save_z;
+    engn_anglexz = cam_frm_save_angle;
+}
+
+/* Interpolation of moving things between game turns.
+ *
+ * Same principle as the camera above. The position of every active thing is
+ * recorded once per game turn; the frames drawn within a turn place each thing
+ * along the path it travelled during the previous turn, and the real positions
+ * are put back as soon as the frame is drawn. The simulation therefore never
+ * sees an interpolated position.
+ */
+
+struct TngFrmPos {
+    long X;
+    long Y;
+    long Z;
+    ulong Turn;
+};
+
+struct TngFrmSaved {
+    ThingIdx Index;
+    long X;
+    long Y;
+    long Z;
+};
+
+static struct TngFrmPos tng_frm_prev[THINGS_LIMIT];
+static struct TngFrmPos tng_frm_curr[THINGS_LIMIT];
+static struct TngFrmPos sth_frm_prev[STHINGS_LIMIT];
+static struct TngFrmPos sth_frm_curr[STHINGS_LIMIT];
+static struct TngFrmSaved tng_frm_saved[THINGS_LIMIT + STHINGS_LIMIT];
+static ushort tng_frm_saved_count = 0;
+
+/** Distance above which a move is taken for a teleport rather than a walk,
+ * and is therefore not interpolated. One map tile: thing coordinates count
+ * 65536 to the tile, which is what the map lookups shift out with `X >> 16`;
+ * the 256 of the render coordinates is a tile there, not here. */
+#define TNG_FRM_JUMP_DIST 65536
+
+/** Records where every active thing stands at the end of the turn whose input
+ * was just processed. To be called once per game turn. */
+static void things_turn_recorded(void)
+{
+    struct Thing *p_thing;
+    struct SimpleThing *p_sthing;
+    ThingIdx thing, nxthing;
+    int remain;
+
+    if (render_frames_per_turn <= 1)
+        return;
+
+    remain = things_used;
+    for (thing = things_used_head; thing > 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_thing = &things[thing];
+        nxthing = p_thing->LinkChild;
+        if (thing >= THINGS_LIMIT)
+            continue;
+        tng_frm_prev[thing] = tng_frm_curr[thing];
+        tng_frm_curr[thing].X = p_thing->X;
+        tng_frm_curr[thing].Y = p_thing->Y;
+        tng_frm_curr[thing].Z = p_thing->Z;
+        tng_frm_curr[thing].Turn = gameturn;
+        // Not followed on the previous turn - a new thing, or a reused slot
+        if (tng_frm_prev[thing].Turn + 1 != gameturn)
+            tng_frm_prev[thing] = tng_frm_curr[thing];
+    }
+
+    remain = sthings_used;
+    for (thing = sthings_used_head; thing < 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_sthing = &sthings[thing];
+        nxthing = p_sthing->LinkChild;
+        if (-thing >= STHINGS_LIMIT)
+            continue;
+        sth_frm_prev[-thing] = sth_frm_curr[-thing];
+        sth_frm_curr[-thing].X = p_sthing->X;
+        sth_frm_curr[-thing].Y = p_sthing->Y;
+        sth_frm_curr[-thing].Z = p_sthing->Z;
+        sth_frm_curr[-thing].Turn = gameturn;
+        if (sth_frm_prev[-thing].Turn + 1 != gameturn)
+            sth_frm_prev[-thing] = sth_frm_curr[-thing];
+    }
+}
+
+/** Places one thing where it should be for the given frame, and remembers the
+ * position it had. Returns nothing; things which must not move are skipped. */
+static void tng_frm_shift(ThingIdx index, long *p_x, long *p_y, long *p_z,
+  const struct TngFrmPos *p_prev, const struct TngFrmPos *p_curr, ushort back)
+{
+    struct TngFrmSaved *p_saved;
+    long dx, dy, dz;
+
+    if (p_curr->Turn != gameturn)
+        return;
+    dx = p_curr->X - p_prev->X;
+    dy = p_curr->Y - p_prev->Y;
+    dz = p_curr->Z - p_prev->Z;
+    // A jump rather than a walk: the thing is placed on the recorded position
+    // instead of being slid across the map towards it
+    if ((labs(dx) > TNG_FRM_JUMP_DIST) || (labs(dz) > TNG_FRM_JUMP_DIST))
+    {
+        dx = 0;
+        dy = 0;
+        dz = 0;
+    }
+
+    p_saved = &tng_frm_saved[tng_frm_saved_count];
+    p_saved->Index = index;
+    p_saved->X = *p_x;
+    p_saved->Y = *p_y;
+    p_saved->Z = *p_z;
+    tng_frm_saved_count++;
+
+    *p_x = p_curr->X - dx * back / render_frames_this_turn;
+    *p_y = p_curr->Y - dy * back / render_frames_this_turn;
+    *p_z = p_curr->Z - dz * back / render_frames_this_turn;
+}
+
+/** Moves every active thing to where it should be for the given frame of the
+ * current turn. Frames are numbered from 0; the last one lands on the position
+ * recorded for this turn.
+ *
+ * Every frame has to be placed from the recording, the last one included. The
+ * live position cannot stand in for it: process_things() runs in the middle of
+ * the turn, between the first frame and the others, so from the second frame
+ * on the live position is a whole turn ahead of what is being drawn. */
+static void things_frame_begin(ushort frame)
+{
+    struct Thing *p_thing;
+    struct SimpleThing *p_sthing;
+    ThingIdx thing, nxthing;
+    int remain;
+    ushort back;
+
+    tng_frm_saved_count = 0;
+    if (render_frames_this_turn <= 1)
+        return;
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+    // How many frames short of the real position this frame stands
+    back = render_frames_this_turn - 1 - frame;
+
+    remain = things_used;
+    for (thing = things_used_head; thing > 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_thing = &things[thing];
+        nxthing = p_thing->LinkChild;
+        if (thing >= THINGS_LIMIT)
+            continue;
+        tng_frm_shift(thing, &p_thing->X, &p_thing->Y, &p_thing->Z,
+          &tng_frm_prev[thing], &tng_frm_curr[thing], back);
+    }
+
+    remain = sthings_used;
+    for (thing = sthings_used_head; thing < 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_sthing = &sthings[thing];
+        nxthing = p_sthing->LinkChild;
+        if (-thing >= STHINGS_LIMIT)
+            continue;
+        tng_frm_shift(thing, &p_sthing->X, &p_sthing->Y, &p_sthing->Z,
+          &sth_frm_prev[-thing], &sth_frm_curr[-thing], back);
+    }
+}
+
+/** Puts back the real position of everything moved for the frame just drawn.
+ * Walks exactly what was moved, so a thing list changed meanwhile cannot
+ * leave a position behind. */
+static void things_frame_end(void)
+{
+    struct TngFrmSaved *p_saved;
+    ushort i;
+
+    for (i = 0; i < tng_frm_saved_count; i++)
+    {
+        p_saved = &tng_frm_saved[i];
+        if (p_saved->Index > 0)
+        {
+            struct Thing *p_thing;
+            p_thing = &things[p_saved->Index];
+            p_thing->X = p_saved->X;
+            p_thing->Y = p_saved->Y;
+            p_thing->Z = p_saved->Z;
+        }
+        else
+        {
+            struct SimpleThing *p_sthing;
+            p_sthing = &sthings[p_saved->Index];
+            p_sthing->X = p_saved->X;
+            p_sthing->Y = p_saved->Y;
+            p_sthing->Z = p_saved->Z;
+        }
+    }
+    tng_frm_saved_count = 0;
+}
+
+/** Prepares and draws one frame of the game engine.
+ *
+ * When advance is false, the parts which move the simulation forward are
+ * skipped, so the frame can be drawn again within the same game turn without
+ * the world ageing twice.
+ */
+void process_engine_frame(TbBool advance, ushort frame)
 {
     PlayerInfo *p_locplayer;
 
-    get_engine_inputs();
+    frame_advances_state = advance;
+
+    // Where the camera ended up for this turn. Recorded here rather than in
+    // the game loop, because the camera is moved during the drawing - by
+    // process_view_inputs() for scrolling and process_engine_unk1() for the
+    // rotation, both of which run just before this function. Recording it
+    // before those ran made every drawn frame show a camera one whole turn
+    // behind, and the last frame of a turn never landed on the real position.
+    if (advance)
+        camera_turn_recorded();
+
+    if (advance)
+        get_engine_inputs();
 
     reset_drawlist();
     ingame.NextRocket = 0;
@@ -1738,9 +2040,10 @@ void process_engine_unk3(void)
     mech_unkn_dw_1DC890 = mech_unkn_tile_x3;
     mech_unkn_dw_1DC894 = mech_unkn_tile_y3;
 
-    process_map_craters();
+    if (advance)
+        process_map_craters();
 
-    if (((ingame.Flags & GamF_BillboardBAT) == 0) &&
+    if (advance && ((ingame.Flags & GamF_BillboardBAT) == 0) &&
       ((ingame.Flags & GamF_BillboardMovies) != 0))
     {
         dword_176CBC += fifties_per_gameturn;
@@ -1758,6 +2061,9 @@ void process_engine_unk3(void)
     int rend_beg_x, rend_beg_z;
     int pos_beg_x, pos_beg_z;
     int tlcount_x, tlcount_z;
+
+    camera_frame_begin(frame);
+    things_frame_begin(frame);
 
     camera_setup_view(&pos_beg_x, &pos_beg_z, &rend_beg_x, &rend_beg_z, &tlcount_x, &tlcount_z);
 
@@ -1804,10 +2110,21 @@ void process_engine_unk3(void)
         ingame.NextRocket = 0;
     }
 
+    things_frame_end();
+    camera_frame_end();
+    frame_advances_state = true;
+
     // Which frame of an animated texture is on screen is not part of the game
     // state - no simulation code reads it. Advanced here, after the frame was
-    // enlisted, it keeps the pace it had within process_things().
-    animate_textures();
+    // enlisted, it keeps the pace it had within process_things() - once per
+    // turn, not once per drawn frame.
+    if (advance)
+        animate_textures();
+}
+
+void process_engine_unk3(void)
+{
+    process_engine_frame(true, 0);
 }
 
 void process_sound_heap(void)
@@ -1928,7 +2245,7 @@ void init_outro(void)
     outro_unkn02 = 0;
     outro_unkn03 = 0;
     gameturn = 0;
-    render_anim_turn = gameturn;
+    render_clock_set_turn(gameturn);
 
     screen_animate_draw_outro_text();
     // Sleep for up to 10 seconds
@@ -1972,7 +2289,7 @@ void init_outro(void)
         }
 
         gameturn++;
-        render_anim_turn = gameturn;
+        render_clock_set_turn(gameturn);
         traffic_unkn_func_01();
         process_engine_unk1();
         process_sound_heap();
@@ -6040,7 +6357,7 @@ void show_load_and_prep_mission(void)
         }
         debug_trace_place(19);
     }
-    render_anim_turn = gameturn;
+    render_clock_set_turn(gameturn);
 
     // Set up remaining graphics data and controls
     if (start_into_mission)
@@ -6505,8 +6822,9 @@ void draw_game(void)
 {
     // One more frame is about to be drawn. The counters the drawing uses
     // advance here, so that they follow the frames and not the game turns.
-    drawturn++;
-    render_anim_turn++;
+    // This is the first frame of the turn; the others are opened by
+    // render_extra_frames().
+    render_clock_next_frame(0, render_frames_this_turn);
 
     switch (ingame.DisplayMode)
     {
@@ -6881,6 +7199,25 @@ void game_process_orbital_station_explode(void)
     }
 }
 
+/** Draws the frames which follow the first one within a game turn. */
+static void render_extra_frames(void)
+{
+    ushort frame;
+
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+    if (skip_redraw_this_turn())
+        return;
+
+    for (frame = 1; frame < render_frames_this_turn; frame++)
+    {
+        render_clock_next_frame(frame, render_frames_this_turn);
+        process_engine_frame(false, frame);
+        game_update();
+        LbScreenSwapClear(0);
+    }
+}
+
 void game_process(void)
 {
     debug_multicolor_sprite(193);
@@ -6888,6 +7225,7 @@ void game_process(void)
 
     while ( !exit_game )
     {
+        render_frames_this_turn = 1;
         process_sound_heap();
         navi2_unkn_counter -= 2;
         if (navi2_unkn_counter < 0)
@@ -6907,6 +7245,13 @@ void game_process(void)
         if ((ingame.DisplayMode == DpM_ENGINEPLY)
           && ((ingame.Flags & TngF_ProgressAction) != 0))
             process_explode();
+        things_turn_recorded();
+        // Only the in-mission view draws more than one frame per turn.
+        // Anywhere else the turn has to keep its full length, or every
+        // screen runs render_frames_per_turn times too fast. Decided before
+        // the first frame, because that frame is one of the several.
+        if ((ingame.DisplayMode == DpM_ENGINEPLY) && !skip_redraw_this_turn())
+            render_frames_this_turn = render_frames_per_turn;
         draw_game();
         debug_trace_turn_bound(gameturn);
         load_packet();
@@ -6933,6 +7278,7 @@ void game_process(void)
         {
             game_update();
             LbScreenSwapClear(0);
+            render_extra_frames();
         }
 
         update_unkn_changing_colors();

--- a/src/game.c
+++ b/src/game.c
@@ -1714,7 +1714,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ((p_thing->Type == TT_BUILDING)
-                         && (p_thing->U.UObject.DrawTurn != gameturn)) {
+                         && (p_thing->U.UObject.DrawTurn != draw_frame)) {
                             draw_thing_object(p_thing);
                         }
                     }
@@ -1752,7 +1752,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ((p_thing->Type == TT_BUILDING)
-                          && (p_thing->U.UObject.DrawTurn != gameturn)
+                          && (p_thing->U.UObject.DrawTurn != draw_frame)
                           && (p_thing->U.UObject.BHeight > 1400)) {
                             draw_thing_object(p_thing);
                         }
@@ -1766,7 +1766,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ( p_thing->Type == TT_BUILDING
-                          && (p_thing->U.UObject.DrawTurn != gameturn)
+                          && (p_thing->U.UObject.DrawTurn != draw_frame)
                           && (p_thing->U.UObject.BHeight > 1400)) {
                             thing = draw_thing_object(p_thing);
                             continue;
@@ -1899,11 +1899,306 @@ void screen_sorted_sprite_persn_render_callback(ushort sspr)
     }
 }
 
-void process_engine_unk3(void)
+/******************************************************************************/
+/* Drawing several frames within one game turn.
+ *
+ * The simulation still advances once per game turn. The extra frames drawn in
+ * between differ only by the camera position, which is moved along the path
+ * the camera travelled during the previous turn. This costs one turn worth of
+ * camera latency, and makes map scrolling smooth.
+ */
+
+static s32 cam_frm_prev_x, cam_frm_prev_z, cam_frm_prev_angle;
+static s32 cam_frm_curr_x, cam_frm_curr_z, cam_frm_curr_angle;
+static s32 cam_frm_save_x, cam_frm_save_z, cam_frm_save_angle;
+
+/** Distance above which a camera move is considered a jump rather than a
+ * scroll, and is therefore not interpolated. Two map tiles. */
+#define CAM_FRM_JUMP_DIST 512
+
+/** A full camera turn, in the units engn_anglexz is kept in. Readers shift it
+ * right by 5 before masking with LbFPMath_AngleMask. */
+#define CAM_FRM_ANGLE_FULL ((LbFPMath_AngleMask + 1) << 5)
+
+/** Records where the camera ended up for the turn whose input was just
+ * processed. To be called once per game turn, right after input(). */
+static void camera_turn_recorded(void)
+{
+    cam_frm_prev_x = cam_frm_curr_x;
+    cam_frm_prev_z = cam_frm_curr_z;
+    cam_frm_prev_angle = cam_frm_curr_angle;
+    cam_frm_curr_x = engn_xc;
+    cam_frm_curr_z = engn_zc;
+    cam_frm_curr_angle = engn_anglexz;
+}
+
+/** Moves the camera to where it should be for the given frame of the current
+ * turn, keeping the real position aside. Frames are numbered from 0, and the
+ * last one lands exactly on the real position. */
+static void camera_frame_begin(ushort frame)
+{
+    s32 dx, dz, dangle;
+
+    cam_frm_save_x = engn_xc;
+    cam_frm_save_z = engn_zc;
+    cam_frm_save_angle = engn_anglexz;
+
+    draw_frame++;
+
+    if (render_frames_per_turn <= 1)
+        return;
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+
+    dx = cam_frm_curr_x - cam_frm_prev_x;
+    dz = cam_frm_curr_z - cam_frm_prev_z;
+    // A jump rather than a scroll - snap instead of sliding across the map.
+    // Checked on its own, so that a camera teleport does not also freeze the
+    // rotation for that turn.
+    if ((abs(dx) <= CAM_FRM_JUMP_DIST) && (abs(dz) <= CAM_FRM_JUMP_DIST))
+    {
+        engn_xc = cam_frm_prev_x + dx * (frame + 1) / render_frames_per_turn;
+        engn_zc = cam_frm_prev_z + dz * (frame + 1) / render_frames_per_turn;
+    }
+
+    // engn_anglexz is a free running accumulator, never masked anywhere in the
+    // tree; readers take (engn_anglexz >> 5) & LbFPMath_AngleMask, so a full
+    // turn is CAM_FRM_ANGLE_FULL and not LbFPMath_AngleMask + 1. Masking it
+    // here used to squeeze the camera into a thirty-second of a turn, which
+    // froze byte_176D49 and with it the facing of every person sprite.
+    dangle = cam_frm_curr_angle - cam_frm_prev_angle;
+    if (labs(dangle) < CAM_FRM_ANGLE_FULL / 2)
+    {
+        engn_anglexz = cam_frm_prev_angle
+          + dangle * (frame + 1) / render_frames_per_turn;
+        camera_update_angle_derived();
+    }
+}
+
+/** Puts the real camera position back after a frame has been drawn. */
+static void camera_frame_end(void)
+{
+    engn_xc = cam_frm_save_x;
+    engn_zc = cam_frm_save_z;
+    engn_anglexz = cam_frm_save_angle;
+}
+
+/* Interpolation of moving things between game turns.
+ *
+ * Same principle as the camera above. The position of every active thing is
+ * recorded once per game turn; the frames drawn within a turn place each thing
+ * along the path it travelled during the previous turn, and the real positions
+ * are put back as soon as the frame is drawn. The simulation therefore never
+ * sees an interpolated position.
+ */
+
+struct TngFrmPos {
+    long X;
+    long Y;
+    long Z;
+    ulong Turn;
+};
+
+struct TngFrmSaved {
+    ThingIdx Index;
+    long X;
+    long Y;
+    long Z;
+};
+
+static struct TngFrmPos tng_frm_prev[THINGS_LIMIT];
+static struct TngFrmPos tng_frm_curr[THINGS_LIMIT];
+static struct TngFrmPos sth_frm_prev[STHINGS_LIMIT];
+static struct TngFrmPos sth_frm_curr[STHINGS_LIMIT];
+static struct TngFrmSaved tng_frm_saved[THINGS_LIMIT + STHINGS_LIMIT];
+static ushort tng_frm_saved_count = 0;
+
+/** Distance above which a move is taken for a teleport rather than a walk,
+ * and is therefore not interpolated. One map tile: thing coordinates count
+ * 65536 to the tile, which is what the map lookups shift out with `X >> 16`;
+ * the 256 of the render coordinates is a tile there, not here. */
+#define TNG_FRM_JUMP_DIST 65536
+
+/** Records where every active thing stands at the end of the turn whose input
+ * was just processed. To be called once per game turn. */
+static void things_turn_recorded(void)
+{
+    struct Thing *p_thing;
+    struct SimpleThing *p_sthing;
+    ThingIdx thing, nxthing;
+    int remain;
+
+    if (render_frames_per_turn <= 1)
+        return;
+
+    remain = things_used;
+    for (thing = things_used_head; thing > 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_thing = &things[thing];
+        nxthing = p_thing->LinkChild;
+        if (thing >= THINGS_LIMIT)
+            continue;
+        tng_frm_prev[thing] = tng_frm_curr[thing];
+        tng_frm_curr[thing].X = p_thing->X;
+        tng_frm_curr[thing].Y = p_thing->Y;
+        tng_frm_curr[thing].Z = p_thing->Z;
+        tng_frm_curr[thing].Turn = gameturn;
+        // Not followed on the previous turn - a new thing, or a reused slot
+        if (tng_frm_prev[thing].Turn + 1 != gameturn)
+            tng_frm_prev[thing] = tng_frm_curr[thing];
+    }
+
+    remain = sthings_used;
+    for (thing = sthings_used_head; thing < 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_sthing = &sthings[thing];
+        nxthing = p_sthing->LinkChild;
+        if (-thing >= STHINGS_LIMIT)
+            continue;
+        sth_frm_prev[-thing] = sth_frm_curr[-thing];
+        sth_frm_curr[-thing].X = p_sthing->X;
+        sth_frm_curr[-thing].Y = p_sthing->Y;
+        sth_frm_curr[-thing].Z = p_sthing->Z;
+        sth_frm_curr[-thing].Turn = gameturn;
+        if (sth_frm_prev[-thing].Turn + 1 != gameturn)
+            sth_frm_prev[-thing] = sth_frm_curr[-thing];
+    }
+}
+
+/** Places one thing where it should be for the given frame, and remembers the
+ * position it had. Returns nothing; things which must not move are skipped. */
+static void tng_frm_shift(ThingIdx index, long *p_x, long *p_y, long *p_z,
+  const struct TngFrmPos *p_prev, const struct TngFrmPos *p_curr, ushort back)
+{
+    struct TngFrmSaved *p_saved;
+    long dx, dy, dz;
+
+    if (p_curr->Turn != gameturn)
+        return;
+    dx = p_curr->X - p_prev->X;
+    dy = p_curr->Y - p_prev->Y;
+    dz = p_curr->Z - p_prev->Z;
+    // A jump rather than a walk: the thing is placed on the recorded position
+    // instead of being slid across the map towards it
+    if ((labs(dx) > TNG_FRM_JUMP_DIST) || (labs(dz) > TNG_FRM_JUMP_DIST))
+    {
+        dx = 0;
+        dy = 0;
+        dz = 0;
+    }
+
+    p_saved = &tng_frm_saved[tng_frm_saved_count];
+    p_saved->Index = index;
+    p_saved->X = *p_x;
+    p_saved->Y = *p_y;
+    p_saved->Z = *p_z;
+    tng_frm_saved_count++;
+
+    *p_x = p_curr->X - dx * back / render_frames_per_turn;
+    *p_y = p_curr->Y - dy * back / render_frames_per_turn;
+    *p_z = p_curr->Z - dz * back / render_frames_per_turn;
+}
+
+/** Moves every active thing to where it should be for the given frame of the
+ * current turn. Frames are numbered from 0; the last one lands on the position
+ * recorded for this turn.
+ *
+ * Every frame has to be placed from the recording, the last one included. The
+ * live position cannot stand in for it: process_things() runs in the middle of
+ * the turn, between the first frame and the others, so from the second frame
+ * on the live position is a whole turn ahead of what is being drawn. */
+static void things_frame_begin(ushort frame)
+{
+    struct Thing *p_thing;
+    struct SimpleThing *p_sthing;
+    ThingIdx thing, nxthing;
+    int remain;
+    ushort back;
+
+    tng_frm_saved_count = 0;
+    if (render_frames_per_turn <= 1)
+        return;
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+    // How many frames short of the real position this frame stands
+    back = render_frames_per_turn - 1 - frame;
+
+    remain = things_used;
+    for (thing = things_used_head; thing > 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_thing = &things[thing];
+        nxthing = p_thing->LinkChild;
+        if (thing >= THINGS_LIMIT)
+            continue;
+        tng_frm_shift(thing, &p_thing->X, &p_thing->Y, &p_thing->Z,
+          &tng_frm_prev[thing], &tng_frm_curr[thing], back);
+    }
+
+    remain = sthings_used;
+    for (thing = sthings_used_head; thing < 0; thing = nxthing)
+    {
+        if (--remain == -1)
+            break;
+        p_sthing = &sthings[thing];
+        nxthing = p_sthing->LinkChild;
+        if (-thing >= STHINGS_LIMIT)
+            continue;
+        tng_frm_shift(thing, &p_sthing->X, &p_sthing->Y, &p_sthing->Z,
+          &sth_frm_prev[-thing], &sth_frm_curr[-thing], back);
+    }
+}
+
+/** Puts back the real position of everything moved for the frame just drawn.
+ * Walks exactly what was moved, so a thing list changed meanwhile cannot
+ * leave a position behind. */
+static void things_frame_end(void)
+{
+    struct TngFrmSaved *p_saved;
+    ushort i;
+
+    for (i = 0; i < tng_frm_saved_count; i++)
+    {
+        p_saved = &tng_frm_saved[i];
+        if (p_saved->Index > 0)
+        {
+            struct Thing *p_thing;
+            p_thing = &things[p_saved->Index];
+            p_thing->X = p_saved->X;
+            p_thing->Y = p_saved->Y;
+            p_thing->Z = p_saved->Z;
+        }
+        else
+        {
+            struct SimpleThing *p_sthing;
+            p_sthing = &sthings[p_saved->Index];
+            p_sthing->X = p_saved->X;
+            p_sthing->Y = p_saved->Y;
+            p_sthing->Z = p_saved->Z;
+        }
+    }
+    tng_frm_saved_count = 0;
+}
+
+/** Prepares and draws one frame of the game engine.
+ *
+ * When advance is false, the parts which move the simulation forward are
+ * skipped, so the frame can be drawn again within the same game turn without
+ * the world ageing twice.
+ */
+void process_engine_frame(TbBool advance, ushort frame)
 {
     PlayerInfo *p_locplayer;
 
-    get_engine_inputs();
+    frame_advances_state = advance;
+
+    if (advance)
+        get_engine_inputs();
 
     reset_drawlist();
     ingame.NextRocket = 0;
@@ -1918,9 +2213,10 @@ void process_engine_unk3(void)
     mech_unkn_dw_1DC890 = mech_unkn_tile_x3;
     mech_unkn_dw_1DC894 = mech_unkn_tile_y3;
 
-    process_map_craters();
+    if (advance)
+        process_map_craters();
 
-    if (((ingame.Flags & GamF_BillboardBAT) == 0) &&
+    if (advance && ((ingame.Flags & GamF_BillboardBAT) == 0) &&
       ((ingame.Flags & GamF_BillboardMovies) != 0))
     {
         dword_176CBC += fifties_per_gameturn;
@@ -1938,6 +2234,9 @@ void process_engine_unk3(void)
     int rend_beg_x, rend_beg_z;
     int pos_beg_x, pos_beg_z;
     int tlcount_x, tlcount_z;
+
+    camera_frame_begin(frame);
+    things_frame_begin(frame);
 
     camera_setup_view(&pos_beg_x, &pos_beg_z, &rend_beg_x, &rend_beg_z, &tlcount_x, &tlcount_z);
 
@@ -1961,7 +2260,8 @@ void process_engine_unk3(void)
     {
         clear_super_quick_lights();
     }
-    process_explode();
+    if (advance)
+        process_explode();
     assert(vec_tmap[1] != NULL);
     vec_map = vec_tmap[1];
     face_transp_tinted_surface_col = deep_radar_surface_col;
@@ -1984,6 +2284,15 @@ void process_engine_unk3(void)
         reset_drawlist();
         ingame.NextRocket = 0;
     }
+
+    things_frame_end();
+    camera_frame_end();
+    frame_advances_state = true;
+}
+
+void process_engine_unk3(void)
+{
+    process_engine_frame(true, 0);
 }
 
 void process_sound_heap(void)
@@ -7141,6 +7450,26 @@ void game_process_orbital_station_explode(void)
     }
 }
 
+/** Draws the frames which follow the first one within a game turn. */
+static void render_extra_frames(void)
+{
+    ushort frame;
+
+    if (render_frames_per_turn <= 1)
+        return;
+    if (ingame.DisplayMode != DpM_ENGINEPLY)
+        return;
+    if (skip_redraw_this_turn())
+        return;
+
+    for (frame = 1; frame < render_frames_per_turn; frame++)
+    {
+        process_engine_frame(false, frame);
+        game_update();
+        LbScreenSwapClear(0);
+    }
+}
+
 void game_process(void)
 {
     debug_multicolor_sprite(193);
@@ -7148,6 +7477,7 @@ void game_process(void)
 
     while ( !exit_game )
     {
+        render_frames_this_turn = 1;
         process_sound_heap();
         navi2_unkn_counter -= 2;
         if (navi2_unkn_counter < 0)
@@ -7161,6 +7491,8 @@ void game_process(void)
         }
         input();
         update_tick_time();
+        camera_turn_recorded();
+        things_turn_recorded();
         draw_game();
         debug_trace_turn_bound(gameturn);
         load_packet();
@@ -7185,8 +7517,15 @@ void game_process(void)
         }
         else if (!skip_redraw_this_turn())
         {
+            // Only the in-mission view draws more than one frame per turn.
+            // Anywhere else the turn has to keep its full length, or every
+            // screen runs render_frames_per_turn times too fast.
+            if (ingame.DisplayMode == DpM_ENGINEPLY)
+                render_frames_this_turn = render_frames_per_turn;
             game_update();
             LbScreenSwapClear(0);
+            render_extra_frames();
+            render_frames_this_turn = 1;
         }
 
         update_unkn_changing_colors();

--- a/src/game_speed.c
+++ b/src/game_speed.c
@@ -19,6 +19,7 @@
 #include "game_speed.h"
 
 #include <assert.h>
+#include <stdlib.h>
 #include "bfkeybd.h"
 #include "bftime.h"
 #include "game.h"
@@ -33,6 +34,31 @@ short frameskip = 0;
 ushort game_num_fps = 16;
 
 ushort fifties_per_gameturn = 3;
+
+ushort render_frames_per_turn = 1;
+
+ushort render_frames_this_turn = 1;
+
+ulong draw_frame = 1;
+
+TbBool frame_advances_state = true;
+
+void render_frames_per_turn_init(void)
+{
+    const char *env;
+    int n;
+
+    env = getenv("SWFX_FRAMES_PER_TURN");
+    if (env == NULL)
+        return;
+    n = atoi(env);
+    if ((n < 1) || (n > 8)) {
+        LOGERR("SWFX_FRAMES_PER_TURN=%s outside of the 1..8 range, ignored", env);
+        return;
+    }
+    render_frames_per_turn = n;
+    LOGSYNC_F("drawing %d frames per game turn", n);
+}
 
 /******************************************************************************/
 
@@ -91,18 +117,43 @@ ubyte get_speed_control_inputs(void)
 void wait_next_gameturn(void)
 {
     static TbClockMSec last_loop_time = 0;
+    static ushort subframe = 0;
+    static ushort last_nframes = 1;
+
     TbClockMSec curr_time = LbTimerClock();
     TbClockMSec sleep_end;
+    TbClockMSec turn_len, period;
+    ushort nframes;
+
+    nframes = render_frames_this_turn;
+    if (nframes < 1)
+        nframes = 1;
+    // The pace changed, ie. a mission was left for a menu; restart the split
+    // so that the frames of a turn keep adding up to one turn
+    if (nframes != last_nframes) {
+        subframe = 0;
+        last_nframes = nframes;
+    }
+    turn_len = 1000/game_num_fps;
+    // Spread the turn over its frames without losing the division remainder,
+    // so that a turn still lasts exactly as long as it used to
+    period = (turn_len * (subframe + 1)) / nframes - (turn_len * subframe) / nframes;
+    subframe++;
+    if (subframe >= nframes)
+        subframe = 0;
+    if (period < 1)
+        period = 1;
 
     if (frameskip == 0)
-        sleep_end = last_loop_time + 1000/game_num_fps;
+        sleep_end = last_loop_time + period;
     else
         sleep_end = curr_time;
     // If we missed the normal sleep target (ie. there was a slowdown), reset the value and do not sleep
-    if ((sleep_end < curr_time) || (sleep_end > curr_time + 1000/game_num_fps)) {
+    if ((sleep_end < curr_time) || (sleep_end > curr_time + turn_len)) {
         LOGNO("missed FPS target, last frame time %ld too far from current %ld",
           (ulong)sleep_end, (ulong)curr_time);
         sleep_end = curr_time;
+        subframe = 0;
     }
     LbSleepUntil(sleep_end);
     last_loop_time = sleep_end;

--- a/src/game_speed.c
+++ b/src/game_speed.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include "bfkeybd.h"
 #include "bftime.h"
+#include "enginprops.h"
 #include "game.h"
 #include "keyboard.h"
 #include "swlog.h"
@@ -35,6 +36,44 @@ GameTurn drawturn = 1;
 ushort game_num_fps = 16;
 
 ushort fifties_per_gameturn = 3;
+
+ushort render_frames_per_turn = 1;
+
+ushort render_frames_this_turn = 1;
+
+/** End of the current animation turn, in 1/256th of a turn. */
+static ulong anim_turn_end = 0;
+
+void render_clock_set_turn(ulong turn)
+{
+    anim_turn_end = turn << 8;
+    render_anim_turn = turn;
+    render_anim_subturn = 0;
+}
+
+void render_clock_next_frame(ushort frame, ushort nframes)
+{
+    ulong clock;
+
+    if (nframes < 1)
+        nframes = 1;
+    if (frame >= nframes)
+        frame = nframes - 1;
+
+    drawturn++;
+    if (frame == 0)
+        anim_turn_end += 256;
+
+    // Where this frame stands within the turn, the last one landing exactly
+    // on it. Set from the turn rather than added up frame by frame: a frame
+    // which had to be dropped for lack of time then costs no animation time,
+    // and the pace stays the same whatever gets drawn.
+    clock = anim_turn_end - 256 + (256 * (ulong)(frame + 1)) / nframes;
+    render_anim_turn = clock >> 8;
+    render_anim_subturn = clock & 0xFF;
+}
+
+TbBool frame_advances_state = true;
 
 /******************************************************************************/
 
@@ -93,18 +132,43 @@ ubyte get_speed_control_inputs(void)
 void wait_next_gameturn(void)
 {
     static TbClockMSec last_loop_time = 0;
+    static ushort subframe = 0;
+    static ushort last_nframes = 1;
+
     TbClockMSec curr_time = LbTimerClock();
     TbClockMSec sleep_end;
+    TbClockMSec turn_len, period;
+    ushort nframes;
+
+    nframes = render_frames_this_turn;
+    if (nframes < 1)
+        nframes = 1;
+    // The pace changed, ie. a mission was left for a menu; restart the split
+    // so that the frames of a turn keep adding up to one turn
+    if (nframes != last_nframes) {
+        subframe = 0;
+        last_nframes = nframes;
+    }
+    turn_len = 1000/game_num_fps;
+    // Spread the turn over its frames without losing the division remainder,
+    // so that a turn still lasts exactly as long as it used to
+    period = (turn_len * (subframe + 1)) / nframes - (turn_len * subframe) / nframes;
+    subframe++;
+    if (subframe >= nframes)
+        subframe = 0;
+    if (period < 1)
+        period = 1;
 
     if (frameskip == 0)
-        sleep_end = last_loop_time + 1000/game_num_fps;
+        sleep_end = last_loop_time + period;
     else
         sleep_end = curr_time;
     // If we missed the normal sleep target (ie. there was a slowdown), reset the value and do not sleep
-    if ((sleep_end < curr_time) || (sleep_end > curr_time + 1000/game_num_fps)) {
+    if ((sleep_end < curr_time) || (sleep_end > curr_time + turn_len)) {
         LOGNO("missed FPS target, last frame time %ld too far from current %ld",
           (ulong)sleep_end, (ulong)curr_time);
         sleep_end = curr_time;
+        subframe = 0;
     }
     LbSleepUntil(sleep_end);
     last_loop_time = sleep_end;

--- a/src/game_speed.h
+++ b/src/game_speed.h
@@ -39,6 +39,27 @@ extern ushort fifties_per_gameturn;
  * turns per second. */
 extern ushort game_num_fps;
 
+/** Amount of frames drawn per game turn. A value of 1 means one drawn frame
+ * per game turn, which is the original behaviour. */
+extern ushort render_frames_per_turn;
+
+/** How many frames the turn being played is actually going to draw. Equal to
+ * render_frames_per_turn while the in-mission view is on screen, and 1
+ * everywhere else, so that menus and other screens keep a full length turn. */
+extern ushort render_frames_this_turn;
+
+/** Counter of drawn frames. Unlike gameturn, it advances once per drawn
+ * frame, so it tells consecutive frames apart even when several are drawn
+ * within a single game turn. */
+extern ulong draw_frame;
+
+void render_frames_per_turn_init(void);
+
+/** Whether the frame being drawn is the one which also carries the game turn
+ * forward. False for the extra frames drawn within a turn, so that anything
+ * animated from within the drawing code keeps its original pace. */
+extern TbBool frame_advances_state;
+
 /**
  * Handles game speed control inputs.
  * @return Returns true if packet was created, false otherwise.

--- a/src/game_speed.h
+++ b/src/game_speed.h
@@ -49,6 +49,34 @@ extern ushort fifties_per_gameturn;
  * turns per second. */
 extern ushort game_num_fps;
 
+/** Highest amount of frames per game turn which can be asked for. Ten is
+ * 160 frames a second, which no machine tried comes near; the bound is there
+ * to catch a mistyped setting, not to express a limit of the drawing. */
+#define FRAMES_PER_TURN_MAX 10
+
+/** Amount of frames drawn per game turn. A value of 1 means one drawn frame
+ * per game turn, which is the original behaviour. */
+extern ushort render_frames_per_turn;
+
+/** How many frames the turn being played is actually going to draw. Equal to
+ * render_frames_per_turn while the in-mission view is on screen, and 1
+ * everywhere else, so that menus and other screens keep a full length turn. */
+extern ushort render_frames_this_turn;
+
+/** Starts a drawn frame: advances drawturn, and moves the animation clock by
+ * the share of the game turn this frame stands for. Frames are numbered from
+ * 0 within the turn; the last one lands the clock exactly on the next turn,
+ * so that a turn always adds up to one whatever the amount of frames. */
+void render_clock_next_frame(ushort frame, ushort nframes);
+
+/** Sets the animation clock to the given turn, on a mission starting. */
+void render_clock_set_turn(ulong turn);
+
+/** Whether the frame being drawn is the one which also carries the game turn
+ * forward. False for the extra frames drawn within a turn, so that anything
+ * animated from within the drawing code keeps its original pace. */
+extern TbBool frame_advances_state;
+
 /**
  * Handles game speed control inputs.
  * @return Returns true if packet was created, false otherwise.

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -379,11 +379,6 @@ short panel_state_to_player_agent(ushort panstate)
     return -1;
 }
 
-/** How much faster the objective text scrolls than it did back when one drawn
- * frame was one game turn. Four keeps the speed the game settled on at four
- * frames per turn; raise it to scroll faster, lower it to slow it down. */
-#define SCANNER_TEXT_SCROLL_RATE 4
-
 void SCANNER_move_objective_info(int width, int height, int end_pos)
 {
     PlayerInfo *p_locplayer;
@@ -418,11 +413,10 @@ void SCANNER_move_objective_info(int width, int height, int end_pos)
     {
         if (end_pos < 0)
             scanner_unkn3CC = width;
-        // The step is divided by the number of frames drawn per turn, so the
-        // text keeps the same speed whatever that number is, while moving in
-        // smaller and more frequent steps when there are more frames.
-        scanner_unkn3CC -= SCANNER_TEXT_SCROLL_RATE * 2 * height
-          / (9 * render_frames_per_turn);
+        // Advanced once per game turn (the caller only runs this on the frame
+        // which carries the turn forward), so the step is the original one,
+        // independent of how many frames are drawn per turn.
+        scanner_unkn3CC -= 2 * height / 9;
     }
 }
 

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -391,23 +391,32 @@ void SCANNER_move_objective_info(int width, int height, int end_pos)
           scanner_unkn370 = -20;
       if (end_pos > lbDisplay.PhysicalScreenWidth - 16)
           scanner_unkn370 = 10;
-      if (scanner_unkn370 > 0)
+      // The chat scroller counts frames, so it only advances on the frame
+      // which carries the turn forward; that keeps its original pace whatever
+      // the number of frames drawn per turn
+      if (frame_advances_state)
       {
-          scanner_unkn370--;
-          scanner_unkn3CC -= 1 * height / 9;
-      }
-      if (scanner_unkn370 < 0)
-      {
-          scanner_unkn370++;
-          scanner_unkn3CC += 1 * height / 9;
-          if (scanner_unkn3CC > 0)
-              scanner_unkn3CC = 0;
+          if (scanner_unkn370 > 0)
+          {
+              scanner_unkn370--;
+              scanner_unkn3CC -= 1 * height / 9;
+          }
+          if (scanner_unkn370 < 0)
+          {
+              scanner_unkn370++;
+              scanner_unkn3CC += 1 * height / 9;
+              if (scanner_unkn3CC > 0)
+                  scanner_unkn3CC = 0;
+          }
       }
     }
     else
     {
         if (end_pos < 0)
             scanner_unkn3CC = width;
+        // Advanced once per game turn (the caller only runs this on the frame
+        // which carries the turn forward), so the step is the original one,
+        // independent of how many frames are drawn per turn.
         scanner_unkn3CC -= 2 * height / 9;
     }
 }
@@ -478,7 +487,10 @@ void draw_objective_info_text(int scr_x, int scr_y, int width, int height)
 
     LbScreenLoadGraphicsWindow(&bkpwnd);
 
-    SCANNER_move_objective_info(width, height, end_pos);
+    // Only on the frame which carries the turn forward, otherwise the text
+    // scrolls as many times faster as there are frames drawn per turn
+    if (frame_advances_state)
+        SCANNER_move_objective_info(width, height, end_pos);
 }
 
 void draw_players_chat(void)

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -379,6 +379,11 @@ short panel_state_to_player_agent(ushort panstate)
     return -1;
 }
 
+/** How much faster the objective text scrolls than it did back when one drawn
+ * frame was one game turn. Four keeps the speed the game settled on at four
+ * frames per turn; raise it to scroll faster, lower it to slow it down. */
+#define SCANNER_TEXT_SCROLL_RATE 4
+
 void SCANNER_move_objective_info(int width, int height, int end_pos)
 {
     PlayerInfo *p_locplayer;
@@ -390,24 +395,34 @@ void SCANNER_move_objective_info(int width, int height, int end_pos)
           scanner_unkn370 = -20;
       if (end_pos > lbDisplay.PhysicalScreenWidth - 16)
           scanner_unkn370 = 10;
-      if (scanner_unkn370 > 0)
+      // The chat scroller counts frames, so it only advances on the frame
+      // which carries the turn forward; that keeps its original pace whatever
+      // the number of frames drawn per turn
+      if (frame_advances_state)
       {
-          scanner_unkn370--;
-          scanner_unkn3CC -= 1 * height / 9;
-      }
-      if (scanner_unkn370 < 0)
-      {
-          scanner_unkn370++;
-          scanner_unkn3CC += 1 * height / 9;
-          if (scanner_unkn3CC > 0)
-              scanner_unkn3CC = 0;
+          if (scanner_unkn370 > 0)
+          {
+              scanner_unkn370--;
+              scanner_unkn3CC -= 1 * height / 9;
+          }
+          if (scanner_unkn370 < 0)
+          {
+              scanner_unkn370++;
+              scanner_unkn3CC += 1 * height / 9;
+              if (scanner_unkn3CC > 0)
+                  scanner_unkn3CC = 0;
+          }
       }
     }
     else
     {
         if (end_pos < 0)
             scanner_unkn3CC = width;
-        scanner_unkn3CC -= 2 * height / 9;
+        // The step is divided by the number of frames drawn per turn, so the
+        // text keeps the same speed whatever that number is, while moving in
+        // smaller and more frequent steps when there are more frames.
+        scanner_unkn3CC -= SCANNER_TEXT_SCROLL_RATE * 2 * height
+          / (9 * render_frames_per_turn);
     }
 }
 
@@ -477,7 +492,10 @@ void draw_objective_info_text(int scr_x, int scr_y, int width, int height)
 
     LbScreenLoadGraphicsWindow(&bkpwnd);
 
-    SCANNER_move_objective_info(width, height, end_pos);
+    // Only on the frame which carries the turn forward, otherwise the text
+    // scrolls as many times faster as there are frames drawn per turn
+    if (frame_advances_state)
+        SCANNER_move_objective_info(width, height, end_pos);
 }
 
 void draw_players_chat(void)

--- a/src/lvdraw3d.c
+++ b/src/lvdraw3d.c
@@ -72,6 +72,27 @@ extern short word_19CC66;
 TbBool nuclear_overexposure = false;
 
 
+/** Blends two values of an animation which steps once per animation turn.
+ *
+ * The surface animations below move by one table entry per turn. When more
+ * than one frame is drawn within a turn, taking the value of the turn alone
+ * makes the surface stand still and then jump; this places it where it should
+ * be for the frame instead. With one frame per turn the fraction is zero and
+ * the value is exactly the one of the turn.
+ */
+static int anim_between_turns(int val_this_turn, int val_next_turn)
+{
+    return val_this_turn
+      + ((val_next_turn - val_this_turn) * (int)render_anim_subturn) / 256;
+}
+
+static int floor_wobble_at_turn(int elcr_x, int elcr_z, int dvfactor, uint anim_turn)
+{
+    return (waft_table2[(anim_turn + (elcr_x >> 7)) & 0x1F]
+         + waft_table2[(anim_turn + (elcr_z >> 7)) & 0x1F]
+         + waft_table2[(32 * anim_turn / dvfactor) & 0x1F]) >> 3;
+}
+
 int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_mapel, int elcr_x, int elcr_z, int mag)
 {
     int elcr_y;
@@ -85,7 +106,8 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
     {
         elcr_y = 8 * p_mapel->Alt;
         if ((p_mapel->Flags & 0x40) != 0)
-            elcr_y += waft_table[render_anim_turn & 0x1F];
+            elcr_y += anim_between_turns(waft_table[render_anim_turn & 0x1F],
+              waft_table[(render_anim_turn + 1) & 0x1F]);
         p_sp->ReflShade = 0;
     }
     else
@@ -94,9 +116,9 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
 
         elcr_y = 8 * p_mapel->Alt;
         dvfactor = 140 + ((bw_rotl32(0x5D3BA6C3, elcr_z >> 8) ^ bw_rotr32(0xA7B4D8AC, elcr_x >> 8)) & 0x7F);
-        wobble = (waft_table2[(render_anim_turn + (elcr_x >> 7)) & 0x1F]
-             + waft_table2[(render_anim_turn + (elcr_z >> 7)) & 0x1F]
-             + waft_table2[(32 * render_anim_turn / dvfactor) & 0x1F]) >> 3;
+        wobble = anim_between_turns(
+          floor_wobble_at_turn(elcr_x, elcr_z, dvfactor, render_anim_turn),
+          floor_wobble_at_turn(elcr_x, elcr_z, dvfactor, render_anim_turn + 1));
         elcr_y += mag * wobble;
         p_sp->ReflShade = (wobble + 32) << 9;
     }

--- a/src/lvdraw3d.c
+++ b/src/lvdraw3d.c
@@ -305,7 +305,7 @@ void lvdraw_do_objects(int cor_z_beg, uint ranges_x_len, struct Range *ranges_x)
             if (objtng > 0)
             {
                 p_objtng = &things[objtng];
-                if (p_objtng->U.UObject.DrawTurn != gameturn)
+                if (p_objtng->U.UObject.DrawTurn != draw_frame)
                     draw_thing_object(p_objtng);
             }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "display.h"
 #include "guitext.h"
 #include "game.h"
+#include "game_speed.h"
 #include "game_data.h"
 #include "game_options.h"
 #include "game_save.h"
@@ -45,6 +46,7 @@ enum ConfigCmd {
     ConfCmd_ResMenu,
     ConfCmd_ResFMVVidHi,
     ConfCmd_ResFMVidLo,
+    ConfCmd_FramesPerTurn,
 };
 
 const struct TbNamedEnum conf_file_cmnds[] = {
@@ -63,6 +65,7 @@ const struct TbNamedEnum conf_file_cmnds[] = {
   {"ResMenu",	ConfCmd_ResMenu},
   {"ResFMVVidHi",ConfCmd_ResFMVVidHi},
   {"ResFMVidLo",ConfCmd_ResFMVidLo},
+  {"FramesPerTurn",ConfCmd_FramesPerTurn},
   {NULL,		0},
 };
 
@@ -524,6 +527,23 @@ void read_conf_file(void)
             case ConfCmd_ResFMVidLo:
                 screen_mode_fmvid_lo = i;
                 break;
+            }
+            break;
+        case ConfCmd_FramesPerTurn:
+            {
+                long nframes;
+
+                if (LbIniValueGetLongInt(&parser, &nframes) <= 0) {
+                    CONFWRNLOG("Couldn't read \"%s\" command parameter.", COMMAND_TEXT(cmd_num));
+                    break;
+                }
+                if ((nframes < 1) || (nframes > FRAMES_PER_TURN_MAX)) {
+                    CONFWRNLOG("Value of \"%s\" is outside of the 1..%d range.",
+                      COMMAND_TEXT(cmd_num), (int)FRAMES_PER_TURN_MAX);
+                    break;
+                }
+                render_frames_per_turn = nframes;
+                CONFDBGLOG("Frames per game turn set to %d", (int)nframes);
             }
             break;
         case 0: // comment

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "display.h"
 #include "guitext.h"
 #include "game.h"
+#include "game_speed.h"
 #include "game_data.h"
 #include "game_options.h"
 #include "game_save.h"
@@ -45,6 +46,7 @@ enum ConfigCmd {
     ConfCmd_ResMenu,
     ConfCmd_ResFMVVidHi,
     ConfCmd_ResFMVidLo,
+    ConfCmd_FramesPerTurn,
 };
 
 const struct TbNamedEnum conf_file_cmnds[] = {
@@ -63,6 +65,7 @@ const struct TbNamedEnum conf_file_cmnds[] = {
   {"ResMenu",	ConfCmd_ResMenu},
   {"ResFMVVidHi",ConfCmd_ResFMVVidHi},
   {"ResFMVidLo",ConfCmd_ResFMVidLo},
+  {"FramesPerTurn",ConfCmd_FramesPerTurn},
   {NULL,		0},
 };
 
@@ -526,6 +529,22 @@ void read_conf_file(void)
                 break;
             }
             break;
+        case ConfCmd_FramesPerTurn:
+            {
+                long nframes;
+
+                if (LbIniValueGetLongInt(&parser, &nframes) <= 0) {
+                    CONFWRNLOG("Couldn't read \"%s\" command parameter.", COMMAND_TEXT(cmd_num));
+                    break;
+                }
+                if ((nframes < 1) || (nframes > 8)) {
+                    CONFWRNLOG("Value of \"%s\" is outside of the 1..8 range.", COMMAND_TEXT(cmd_num));
+                    break;
+                }
+                render_frames_per_turn = nframes;
+                CONFDBGLOG("Frames per game turn set to %d", (int)nframes);
+            }
+            break;
         case 0: // comment
             break;
         case -1: // end of buffer
@@ -564,6 +583,7 @@ main (int argc, char **argv)
         return 1;
 
     read_conf_file();
+    render_frames_per_turn_init();
     setup_language_file_names();
 
     display_set_full_screen(cmdln_fullscreen);

--- a/src/tngobjdrw.c
+++ b/src/tngobjdrw.c
@@ -433,9 +433,9 @@ void build_building(struct Thing *p_thing)
             return;
     }
 
-    if (gameturn == p_thing->U.UObject.DrawTurn)
+    if (draw_frame == p_thing->U.UObject.DrawTurn)
         return;
-    p_thing->U.UObject.DrawTurn = gameturn;
+    p_thing->U.UObject.DrawTurn = draw_frame;
 
     if (p_thing->SubType == SubTT_BLD_BILLBOARD)
     {

--- a/swrendersoft/include/enginpeff.h
+++ b/swrendersoft/include/enginpeff.h
@@ -21,6 +21,8 @@
 
 #include "bftypes.h"
 
+#include "enginprops.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,6 +69,25 @@ extern const short waft_table2[32];
  * The period of this table is 32, last element repeats first.
  */
 extern const short waft_table[33];
+
+/** Value of waft_table between the given animation turn and the next one.
+ *
+ * Everything which bobs on a wobbly terrain map moves by one table entry per
+ * animation turn. When several frames are drawn within a turn, this places it
+ * where it should be for the frame instead of leaving it still until the turn
+ * ends. With one frame per turn the value is the one the table holds.
+ *
+ * Inline on purpose: its callers sit next to inline assembly, and a call
+ * there would move registers around for no gain.
+ */
+static inline int waft_between_turns(uint anim_turn)
+{
+    int v0, v1;
+
+    v0 = waft_table[anim_turn & 0x1F];
+    v1 = waft_table[(anim_turn + 1) & 0x1F];
+    return v0 + ((v1 - v0) * (int)render_anim_subturn) / 256;
+}
 
 void scene_post_effect_prepare(void);
 void scene_post_effect_for_bucket(short bckt);

--- a/swrendersoft/include/enginprops.h
+++ b/swrendersoft/include/enginprops.h
@@ -55,6 +55,15 @@ enum RenderFacesFlags {
  */
 extern u32 render_anim_turn;
 
+/** Position within the current animation turn, in 1/256th of a turn.
+ *
+ * Always zero when one frame is drawn per game turn. When several are, it
+ * tells how far into the turn the frame being drawn stands, so that an
+ * animation which only advances once per turn can be drawn in between its
+ * two steps rather than jumping.
+ */
+extern u32 render_anim_subturn;
+
 /** Animation speed limiter.
  *
  * Lowering this will speed up animation. Increasing will only have effect

--- a/swrendersoft/include/engintrns.h
+++ b/swrendersoft/include/engintrns.h
@@ -106,6 +106,11 @@ int transform_shpoint_y(int dxc, int dyc, int dzc);
 void transform_screen_to_map_isometric(int *dxc, int *dzc, int scr_x, int scr_y);
 
 void process_engine_unk1(void);
+
+/** Recomputes the values derived from engn_anglexz, without advancing the
+ * camera rotation. Needed when the angle is set outside of
+ * process_engine_unk1(), as interpolated frames do. */
+void camera_update_angle_derived(void);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/swrendersoft/src/engindrwlstm_3d.c
+++ b/swrendersoft/src/engindrwlstm_3d.c
@@ -117,7 +117,7 @@ void enlist_draw_frame_graphic(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -145,7 +145,7 @@ void enlist_draw_frame_graphic_scale(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -262,7 +262,7 @@ void enlist_draw_fire_flames(ushort flame_beg)
         cor_dz = p_flame->z - engn_zc;
 
         if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-            cor_dy += waft_table[render_anim_turn & 0x1F];
+            cor_dy += waft_between_turns(render_anim_turn);
 
         transform_shpoint(&sp, cor_dx, cor_dy - 8 * engn_yc, cor_dz);
 
@@ -413,7 +413,7 @@ void enlist_draw_number(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -441,7 +441,7 @@ void enlist_draw_text(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 

--- a/swrendersoft/src/enginprops.c
+++ b/swrendersoft/src/enginprops.c
@@ -21,6 +21,7 @@
 #include "privrdlog.h"
 /******************************************************************************/
 u32 render_anim_turn = 0;
+u32 render_anim_subturn = 0;
 u32 render_anim_speed = 80;
 u32 render_floor_flags = 0;
 u32 render_faces_flags = 0;

--- a/swrendersoft/src/engintrns.c
+++ b/swrendersoft/src/engintrns.c
@@ -306,6 +306,16 @@ int transform_shpoint_y(int dxc, int dyc, int dzc)
     return scr_y;
 }
 
+void camera_update_angle_derived(void)
+{
+    int angle;
+
+    angle = (engn_anglexz >> 5) & LbFPMath_AngleMask;
+    dword_176D0C = angle;
+    dword_176D14 = lbSinTable[angle + LbFPMath_PI/2];
+    dword_176D10 = lbSinTable[angle];
+}
+
 void process_engine_unk1(void)
 {
     int angle;
@@ -315,10 +325,7 @@ void process_engine_unk1(void)
     dword_176D40 = vec_window_height / 2;
     engn_anglexz += cam_rotation_velocity;
     dword_176D44 = 4 * (vec_window_width / 2) / 3;
-    angle = (engn_anglexz >> 5) & LbFPMath_AngleMask;
-    dword_176D0C = angle;
-    dword_176D14 = lbSinTable[angle + LbFPMath_PI/2];
-    dword_176D10 = lbSinTable[angle];
+    camera_update_angle_derived();
     angle = cam_tilt & LbFPMath_AngleMask;
     dword_176D18 = lbSinTable[angle];
     dword_176D1C = lbSinTable[angle + LbFPMath_PI/2];

--- a/swrendersoft/src/engintrns.c
+++ b/swrendersoft/src/engintrns.c
@@ -1,3 +1,4 @@
+#pragma GCC optimize ("O2", "no-strict-aliasing")
 /******************************************************************************/
 // Syndicate Wars Fan Expansion, source port of the classic game from Bullfrog.
 /******************************************************************************/
@@ -306,6 +307,16 @@ int transform_shpoint_y(int dxc, int dyc, int dzc)
     return scr_y;
 }
 
+void camera_update_angle_derived(void)
+{
+    int angle;
+
+    angle = (engn_anglexz >> 5) & LbFPMath_AngleMask;
+    dword_176D0C = angle;
+    dword_176D14 = lbSinTable[angle + LbFPMath_PI/2];
+    dword_176D10 = lbSinTable[angle];
+}
+
 void process_engine_unk1(void)
 {
     int angle;
@@ -315,10 +326,7 @@ void process_engine_unk1(void)
     dword_176D40 = vec_window_height / 2;
     engn_anglexz += cam_rotation_velocity;
     dword_176D44 = 4 * (vec_window_width / 2) / 3;
-    angle = (engn_anglexz >> 5) & LbFPMath_AngleMask;
-    dword_176D0C = angle;
-    dword_176D14 = lbSinTable[angle + LbFPMath_PI/2];
-    dword_176D10 = lbSinTable[angle];
+    camera_update_angle_derived();
     angle = cam_tilt & LbFPMath_AngleMask;
     dword_176D18 = lbSinTable[angle];
     dword_176D1C = lbSinTable[angle + LbFPMath_PI/2];

--- a/swrendersoft/src/engintrns.c
+++ b/swrendersoft/src/engintrns.c
@@ -1,4 +1,3 @@
-#pragma GCC optimize ("O2", "no-strict-aliasing")
 /******************************************************************************/
 // Syndicate Wars Fan Expansion, source port of the classic game from Bullfrog.
 /******************************************************************************/


### PR DESCRIPTION
Follows from the discussion in #24, and is the "reviewable pieces" I offered there rather than the mixed local branch.

**What it does.** The simulation still runs at a fixed 16 turns per second. A `FramesPerTurn` setting (1 to 8, default 1, so stock behaviour is unchanged) draws that many frames per turn. The extra frames advance nothing: they redraw the scene with the camera and every active thing moved along the path they travelled during the previous turn, and the real positions are restored before the next turn, so the simulation never sees an interpolated value.

- `process_engine_frame(advance, frame)` splits the old `process_engine_unk3` into state-advancing work (input, craters, billboards, explosions) and drawing work; only the first frame of a turn advances.
- Camera and thing positions are recorded once per turn and restored right after each frame. Moves longer than a tile are treated as teleports and not interpolated.
- `camera_update_angle_derived()` recomputes the values derived from the camera angle when an interpolated frame sets it directly.
- The "already drawn this turn" marker on buildings (`DrawTurn`) counts drawn frames rather than turns, otherwise buildings vanish on the second pass.
- The objective text scroller advances only on the frame that carries the turn forward, so its speed is unchanged.
- Only the in-mission view draws extra frames; menus and other screens keep a full-length turn.

Read from the config file (`FramesPerTurn`) and from `SWFX_FRAMES_PER_TURN` in the environment.

**Deliberately not here.** The local branch also carried renderer-speed changes — building `swrendersoft` optimised, and unrolling the rasteriser span loop. Those belong with #413 and #416, not with a gameplay change. The consequence is that `FramesPerTurn` above 1 only fits the turn budget at lower resolutions on current hardware: the measurements in #413 show a single frame already taking 57 ms at 1920x1080 and 96 ms at 2560x1440 against a 62 ms budget with the stock `-O0` build. The split still stands on its own as the answer to this thread's request — lowering the turn rate towards the 1996 feel without the motion turning choppy — and as the groundwork that #413's optimisation would then make usable at full resolution.

**Testing.** Built and run 32-bit on Linux.

- At the default (`FramesPerTurn` 1) a mission's turn rate and per-turn timing match a stock build exactly.
- Determinism: recorded a single-player mission with a stock build, then replayed it with this branch at one and at two frames per turn. The recorded RNG seed matches the live one on every turn for the whole replay, so the extra frames do not perturb the simulation.
- `FramesPerTurn` 2 checked on screen: motion is smoother, game speed unchanged.

Not tested: network play.
