### PR TITLE
bflibrary: Point render_ghost at the ghost table when it is set up

### DIFF
--- a/bflibrary/src/general/ggengh.c
+++ b/bflibrary/src/general/ggengh.c
@@ -22,6 +22,7 @@
 #include "bffile.h"
 #include "bfpalette.h"
 #include "bfscreen.h"
+#include "insspr.h"
 #include "privbflog.h"
 
 static void ghost_table_generate(const ubyte *pal, short mix_ratio,
@@ -130,6 +131,7 @@ TbResult LbGhostTableGenerate(const ubyte *pal, short mix_ratio, const char *fna
         }
     }
     lbDisplay.GlassMap = pixmap.ghost_table;
+    render_ghost = pixmap.ghost_table;
     return Lb_SUCCESS;
 }
 
@@ -139,6 +141,7 @@ TbResult LbGhostTableLoad(const ubyte *pal, short mix_ratio, const char *fname)
 
     len = LbFileLoadAt(fname, pixmap.ghost_table);
     lbDisplay.GlassMap = pixmap.ghost_table;
+    render_ghost = pixmap.ghost_table;
 
     // At 50% mix ratio, the palette should be diagonally symmetrical.
     if (mix_ratio == 50) {

--- a/bflibrary/src/general/spr_scl.c
+++ b/bflibrary/src/general/spr_scl.c
@@ -36,8 +36,6 @@ long alpha_scale_up;
 // TODO move these to rendering/trig data module
 TbPixel *render_ghost = NULL;
 TbPixel *render_alpha = NULL;
-//TODO currently, render_ghost is unused; but to make it ready to use, we need to set:
-//render_ghost = lbSpriteReMapPtr;
 
 
 void LbSpriteSetScalingWidthClippedArray(long * xsteps_arr, long x, long swidth, long dwidth, long gwidth)

--- a/bflibrary/tests/bflib_test_sprdrw.c
+++ b/bflibrary/tests/bflib_test_sprdrw.c
@@ -359,7 +359,6 @@ TbBool test_spritedraw(void)
     make_general_palette(pal);
     LbFileSaveAt("tst_gp.pal", &pal, sizeof(pal));
     LbColourTablesGenerate(pal, unaffected_colours, "tst_gptbl.dat");
-    render_ghost = &pixmap.ghost_table[0*PALETTE_8b_COLORS];
 
     // Generate sprite DAT/TAB loaded data to test
     if (!test_spritedraw_generate(sprfile_no, pal, &p_sprdata, &p_sprlist, &tot_sprites)) {

--- a/swrendersoft/src/engindrwlstx_spr.c
+++ b/swrendersoft/src/engindrwlstx_spr.c
@@ -400,8 +400,6 @@ void draw_frame_scaled_alpha(int scr_x, int scr_y, ushort frm,
     p_frm = &frame[frm];
     assert(p_frm < frame_end);
     lbSpriteReMapPtr = &pixmap.fade_table[256 * alpha];
-    //TODO would probably make more sense to set the ghost ptr somewhere during game setup
-    render_ghost = &pixmap.ghost_table[0*PALETTE_8b_COLORS];
 
     pos_x = 99999;
     pos_y = 99999;


### PR DESCRIPTION
Starting mission 34 of the first campaign - the Singapore map - aborts on
`assert(render_ghost != NULL)` in LbSpriteDrawUsingScalingData(), reached from
number_player() inside draw_hud(), on the first drawn frame. That mission is a
normal campaign level: `map009.mad` / `c009l001.dat`, Eurocorp mail 04.

render_ghost was only ever assigned as a side effect of
draw_frame_scaled_alpha(), which carries a TODO saying it would make more sense
to set it during game setup. On most maps that function happens to run before
anything else draws a scaled ghosted sprite, so the pointer is set in time; on
that one the HUD gets there first, with the pointer still NULL. In a build with
asserts disabled this is a NULL dereference rather than an abort.

It is now set next to `lbDisplay.GlassMap`, in both LbGhostTableGenerate() and
LbGhostTableLoad(), which is where the table it points into becomes usable. The
value assigned is the one draw_frame_scaled_alpha() used, so nothing which
worked before draws differently.

Checked on missions 1, 21 and 34 of the first campaign: 34 used to abort on its
first drawn frame and now runs, the other two are unaffected. Those runs were
made before rebasing onto current master, where the change applies without
conflict.
