### PR TITLE
Push the stack arguments of bul_path_end through a register

### DIFF
--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1501,14 +1501,29 @@ int bul_path_end(int x1, int y1, int z1, int *x2, int *y2, int *z2,
   int radius, struct Thing *p_owner, ubyte *status)
 {
     int ret;
+    // The five arguments which go on the stack are gathered first, and pushed
+    // through a register holding the address of that array. A "g" operand may
+    // be placed relative to the stack pointer, and each push moves it, so
+    // pushing straight from the operands reads the wrong slot from the second
+    // push on - which is what an optimised build does.
+    int stkargs[5];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = radius;
+    stkargs[3] = (int)(intptr_t)p_owner;
+    stkargs[4] = (int)(intptr_t)status;
+
     asm volatile (
-      "push %9\n"
-      "push %8\n"
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 16(%5)\n"
+      "push 12(%5)\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_bul_path_end\n"
-        : "=r" (ret) : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (radius), "g" (p_owner), "g" (status));
+        : "=a" (ret)
+        : "0" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 


### PR DESCRIPTION
Related to #413.

An optimised build segfaults in ASM_bul_path_end as soon as a mission starts
drawing. The wrapper pushes five arguments before the call, and lets the
compiler choose where they live:

    "push %9\n" ... "push %5\n" "call ASM_bul_path_end\n"
    : "=r" (ret) : "a"(x1),"d"(y1),"b"(z1),"c"(x2),
      "g"(y2),"g"(z2),"g"(radius),"g"(p_owner),"g"(status)

A "g" operand may be a memory operand, and which base register addresses it is
the compiler's choice. Without optimisation it picks the frame pointer, which
the pushes do not disturb:

    push 0x28(%ebp) ; push 0x24(%ebp) ; push 0x20(%ebp) ...

With -O2 there is no frame pointer and it picks the stack pointer, which every
push moves by four while the offsets stay as they were written:

    push 0x28(%esp) ; push 0x24(%esp) ; push 0x20(%esp) ...

The second push therefore reads the slot the first one read, and every argument
after the first is off by one place. The callee receives pointers which are not
pointers. -fno-omit-frame-pointer does not help: no frame is set up for this
function either way.

The five values are gathered into a local array first, and pushed through a
register holding its address, which no push can move. The return value moves
from "=r" to "=a", the register the call actually returns it in, and the clobber
list gains "cc" and "memory" - the callee writes through three of those
pointers.

Measured with CFLAGS="-m32 -fPIC -O2", gcc 15.2, 32 bit:

  - before, every mission tried aborted on its first drawn frame;
  - after, missions 1, 3, 5, 21, 34, 49 and 109 of the first campaign each ran
    300 turns with no crash;
  - the optimised build draws the same picture as the unoptimised one: over 200
    turns of the first mission, screen contents, thing states and the value of
    lbSeed are identical between the two;
  - it is also 3.1 times faster on that run, 9.28 against 2.99 turns per second
    at 1920x1080.

Those runs were made before rebasing onto current master, where the change
applies without conflict.

The same shape - pushes reading "g" operands - appears in 155 other places in
the tree. This is the only one reached in the runs above, but they are all
wrong in the same way, and on another machine an optimised build still drops
objects from the picture without crashing, so at least one of the others bites.
