### PR TITLE
Progress screen-only animations with the drawing, world state with the world

### DIFF
--- a/src/engindrwlstm_wrp.c
+++ b/src/engindrwlstm_wrp.c
@@ -241,7 +241,7 @@ void draw_pers_e_graphic(struct Thing *p_thing,
     br_inc = person_shield_glow_brightness(p_thing);
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[gameturn & 0x1F] >> 3;
+        cor_dy += waft_table[render_anim_turn & 0x1F] >> 3;
 
     transform_shpoint(&sp, cor_dx, 8 * cor_dy - 8 * engn_yc, cor_dz);
 
@@ -769,7 +769,7 @@ int draw_rot_object(int cor_dx, int cor_dy, int cor_dz,
     assert((p_thing->U.UObject.MatrixIndex < next_local_mat) || (p_thing->Type == TT_ROCKET));
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[gameturn & 0x1F];
+        cor_dy += waft_table[render_anim_turn & 0x1F];
 
     object_points_clear_flags(point_object);
 
@@ -828,7 +828,7 @@ short draw_object_faces(int cor_dx, int cor_dy, int cor_dz,
     depth_shift = point_object->field_1E;
 
     if ((point_object->field_1C & 0x0100) != 0 && ((doflags & DrwObjF_NoWobblyElevation) == 0))
-        cor_dy += waft_table[gameturn & 0x1F];
+        cor_dy += waft_table[render_anim_turn & 0x1F];
 
     bckt_max = 0;
 

--- a/src/game.c
+++ b/src/game.c
@@ -1714,7 +1714,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ((p_thing->Type == TT_BUILDING)
-                         && (p_thing->U.UObject.DrawTurn != gameturn)) {
+                         && (p_thing->U.UObject.DrawTurn != drawturn)) {
                             draw_thing_object(p_thing);
                         }
                     }
@@ -1752,7 +1752,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ((p_thing->Type == TT_BUILDING)
-                          && (p_thing->U.UObject.DrawTurn != gameturn)
+                          && (p_thing->U.UObject.DrawTurn != drawturn)
                           && (p_thing->U.UObject.BHeight > 1400)) {
                             draw_thing_object(p_thing);
                         }
@@ -1766,7 +1766,7 @@ void engine_draw_things(int pos_beg_x, int pos_beg_z, int rend_beg_x, int rend_b
                         struct Thing *p_thing;
                         p_thing = &things[thing];
                         if ( p_thing->Type == TT_BUILDING
-                          && (p_thing->U.UObject.DrawTurn != gameturn)
+                          && (p_thing->U.UObject.DrawTurn != drawturn)
                           && (p_thing->U.UObject.BHeight > 1400)) {
                             thing = draw_thing_object(p_thing);
                             continue;
@@ -1961,7 +1961,6 @@ void process_engine_unk3(void)
     {
         clear_super_quick_lights();
     }
-    process_explode();
     assert(vec_tmap[1] != NULL);
     vec_map = vec_tmap[1];
     face_transp_tinted_surface_col = deep_radar_surface_col;
@@ -1984,6 +1983,11 @@ void process_engine_unk3(void)
         reset_drawlist();
         ingame.NextRocket = 0;
     }
+
+    // Which frame of an animated texture is on screen is not part of the game
+    // state - no simulation code reads it. Advanced here, after the frame was
+    // enlisted, it keeps the pace it had within process_things().
+    animate_textures();
 }
 
 void process_sound_heap(void)
@@ -6768,6 +6772,11 @@ void show_game_screen(void)
 
 void draw_game(void)
 {
+    // One more frame is about to be drawn. The counters the drawing uses
+    // advance here, so that they follow the frames and not the game turns.
+    drawturn++;
+    render_anim_turn++;
+
     switch (ingame.DisplayMode)
     {
     case DpM_UNKN_1:
@@ -7161,6 +7170,12 @@ void game_process(void)
         }
         input();
         update_tick_time();
+        // Faces thrown by an explosion can hit people once they land, so they
+        // are world state and progress with the world - not from within the
+        // renderer, where this used to be called from.
+        if ((ingame.DisplayMode == DpM_ENGINEPLY)
+          && ((ingame.Flags & TngF_ProgressAction) != 0))
+            process_explode();
         draw_game();
         debug_trace_turn_bound(gameturn);
         load_packet();
@@ -7192,7 +7207,6 @@ void game_process(void)
         update_unkn_changing_colors();
         game_process_orbital_station_explode();
         gameturn++;
-        render_anim_turn = gameturn;
         scene_post_effect_prepare();
     }
     PacketRecord_Close();

--- a/src/game_speed.c
+++ b/src/game_speed.c
@@ -29,6 +29,8 @@
 
 short frameskip = 0;
 
+GameTurn drawturn = 1;
+
 // TODO implement separate turns per second, when drawing frames will get separated from game loop
 ushort game_num_fps = 16;
 

--- a/src/game_speed.h
+++ b/src/game_speed.h
@@ -32,6 +32,16 @@ extern ulong curr_tick_time;
 extern ulong prev_tick_time;
 extern GameTurn gameturn;
 extern GameTurn prev_gameturn;
+
+/** Counter of frames drawn to the screen.
+ *
+ * Advances once per drawn frame. It is the counter for things which only
+ * exist while drawing - marking which elements were already drawn within the
+ * current frame, for instance. Nothing in the simulation reads it, so drawing
+ * code should use it rather than `gameturn` whenever it only needs to tell
+ * one frame from the next.
+ */
+extern GameTurn drawturn;
 extern ulong turns_delta;
 extern ushort fifties_per_gameturn;
 

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -36,6 +36,7 @@
 #include "engincam.h"
 #include "engincolour.h"
 #include "enginpeff.h"
+#include "enginprops.h"
 #include "engintxtrmap.h"
 #include "render_gpoly.h"
 
@@ -1599,8 +1600,8 @@ void draw_transparent_slant_bar(short x, short y, ushort w, ushort h)
     point3.pp.X = (x - sh_x);
 
     // The shield bar is animated, even if it's not possible to see
-    waftx = waft_table[(gameturn >> 3) & 31];
-    wafty = waft_table[(gameturn + 16) & 31];
+    waftx = waft_table[(render_anim_turn >> 3) & 31];
+    wafty = waft_table[(render_anim_turn + 16) & 31];
     tmx = ((waftx + 30) >> 1);
     tmy = ((wafty + 30) >> 3) + 64;
     point1.pp.U = tmx << 16;

--- a/src/lvdraw3d.c
+++ b/src/lvdraw3d.c
@@ -31,6 +31,7 @@
 #include "enginfloor.h"
 #include "enginlights.h"
 #include "enginpeff.h"
+#include "enginprops.h"
 #include "engintrns.h"
 #include "engintxtrmap.h"
 #include "enginzoom.h"
@@ -83,7 +84,7 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
     {
         elcr_y = 8 * p_mapel->Alt;
         if ((p_mapel->Flags & 0x40) != 0)
-            elcr_y += waft_table[gameturn & 0x1F];
+            elcr_y += waft_table[render_anim_turn & 0x1F];
         p_sp->ReflShade = 0;
     }
     else
@@ -92,9 +93,9 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
 
         elcr_y = 8 * p_mapel->Alt;
         dvfactor = 140 + ((bw_rotl32(0x5D3BA6C3, elcr_z >> 8) ^ bw_rotr32(0xA7B4D8AC, elcr_x >> 8)) & 0x7F);
-        wobble = (waft_table2[(gameturn + (elcr_x >> 7)) & 0x1F]
-             + waft_table2[(gameturn + (elcr_z >> 7)) & 0x1F]
-             + waft_table2[(32 * gameturn / dvfactor) & 0x1F]) >> 3;
+        wobble = (waft_table2[(render_anim_turn + (elcr_x >> 7)) & 0x1F]
+             + waft_table2[(render_anim_turn + (elcr_z >> 7)) & 0x1F]
+             + waft_table2[(32 * render_anim_turn / dvfactor) & 0x1F]) >> 3;
         elcr_y += mag * wobble;
         p_sp->ReflShade = (wobble + 32) << 9;
     }
@@ -305,7 +306,7 @@ void lvdraw_do_objects(int cor_z_beg, uint ranges_x_len, struct Range *ranges_x)
             if (objtng > 0)
             {
                 p_objtng = &things[objtng];
-                if (p_objtng->U.UObject.DrawTurn != gameturn)
+                if (p_objtng->U.UObject.DrawTurn != drawturn)
                     draw_thing_object(p_objtng);
             }
         }

--- a/src/thing.c
+++ b/src/thing.c
@@ -1184,7 +1184,6 @@ void process_things(void)
 #endif
     build_same_type_headers();
     ingame.fld_unkC4B = 0;
-    animate_textures();
     unkn_update_lights();
     unkn_full_update_lights();
 

--- a/src/tngobjdrw.c
+++ b/src/tngobjdrw.c
@@ -433,9 +433,9 @@ void build_building(struct Thing *p_thing)
             return;
     }
 
-    if (gameturn == p_thing->U.UObject.DrawTurn)
+    if (drawturn == p_thing->U.UObject.DrawTurn)
         return;
-    p_thing->U.UObject.DrawTurn = gameturn;
+    p_thing->U.UObject.DrawTurn = drawturn;
 
     if (p_thing->SubType == SubTT_BLD_BILLBOARD)
     {

--- a/swrendersoft/include/enginprops.h
+++ b/swrendersoft/include/enginprops.h
@@ -48,8 +48,10 @@ enum RenderFacesFlags {
  * Such animations use this value as a measure of progressing time, and
  * therefore progressing animation frames.
  *
- * The value is expected to be incremented or set to game turns within
- * the game code.
+ * The value is expected to be incremented once per drawn frame within the
+ * game code. It is deliberately not tied to game turns: nothing in the
+ * simulation reads it, and an animation which does not touch the game world
+ * has no reason to wait for one.
  */
 extern u32 render_anim_turn;
 


### PR DESCRIPTION
This is the groundwork asked for on #422, on its own and without any frame rate
change: one frame is still drawn per game turn.

Four things were on the wrong clock.

  - a new counter, drawturn, advances once per drawn frame. Buildings are
    marked as already drawn within the current frame with it, instead of with
    gameturn;

  - render_anim_turn is incremented once per drawn frame rather than assigned
    from gameturn at the end of every turn, and the places which read gameturn
    from within drawing code to animate something - the water surface wobble in
    shpoint_compute_coord_y(), the shield bar in the HUD, and the elevation
    added to sprites and objects on a wobbly terrain map - read it instead;

  - animate_textures() moves from process_things() to the end of the engine
    draw. Which frame of an animated texture is on screen is not read by any
    simulation code. Its position in the sequence is unchanged;

  - process_explode() moves out of process_engine_unk3() into the game loop,
    behind TngF_ProgressAction. The faces thrown by an exploding object are
    world state - they generate debris which can hit a person when they land -
    so they are progressed with the world. This also fixes them continuing to
    fall while the action is stopped with ctrl-F3.

One frame is still drawn per game turn, so drawturn and render_anim_turn
advance at the rate gameturn did. Checked on the first mission and on mission
34 over 200 turns, comparing every 20 turns against the commit before: screen
contents identical, thing states identical, lbSeed identical. The only
difference is the number stored in the DrawTurn marker field, which no longer
matches the game turn; nothing reads it as a turn number. Those runs were made
before rebasing onto current master, where the change applies without conflict.

The fourth point raised on #422 - drawing code writing into game state through
callbacks - is not addressed here. Having gone through them, it comes down to
the mouse target: player_target_clear() followed by check_mouse_overvehicle()
and the check_mouse_overlap* family from the three screen_*_render_callback
hooks, plus ingame.VisibleBillboardThing in build_building(). All of it is
cleared and recomputed from scratch within each frame, so nothing accumulates,
but it is still the renderer writing where the simulation reads. Taking it out
means computing the target outside the draw, which is a larger change than this
one and I would rather do it separately if you want it done.
