### PR TITLE
syndwarsfx: Do not ask for a mod animation when no mod is selected

### DIFF
--- a/src/fecryo.c
+++ b/src/fecryo.c
@@ -191,7 +191,9 @@ void update_cybmod_name_text(void)
 
 TbBool cybmod_has_display_anim(ubyte mod)
 {
-    return (1 << (mod - 1) < 0x1000);
+    if (mod < 1) // No mod selected
+        return false;
+    return ((1 << (mod - 1)) < 0x1000);
 }
 
 void cryo_display_box_redraw(struct ScreenTextBox *p_box)


### PR DESCRIPTION
Fixes #415, taking you up on the go-ahead.

This is the shape you suggested: `cybmod_has_display_anim()` gets the same
zero check `weapon_has_display_anim()` has a few lines away in `feequip.c`.

The mechanism, in case it is useful elsewhere. The function was

```c
return (1 << (mod - 1) < 0x1000);
```

With `mod == 0` that is a shift by -1. `mod` is promoted to `int`, the shift
count is negative, and the behaviour is undefined; gcc leaves a negative
value, which compares below `0x1000`, so the answer comes out true.
`cryo_display_box_redraw()` then takes the `DiBoxCt_ANIM` path and calls
`init_weapon_anim(selected_mod + 31)`, which asks for `wep-31.fli`.

I compiled the expression on its own as 32-bit to check the rest of the range
rather than assume it: only zero was wrong. Mods 1 to 12 answer true and 13
upwards false, before and after.

The shift is parenthesised while I am in there. It was already grouped that
way — `<<` binds tighter than `<` — so this changes nothing, it just says so.

On the look of it: the panel falls back to the text path and stays blank,
which is what the weapons screen already does with no weapon selected. Still
happy to change that if you would rather it showed something.
