### PR TITLE
Push stack arguments through a register wherever there are several

### DIFF
--- a/src/bmbang.c
+++ b/src/bmbang.c
@@ -39,11 +39,19 @@ void bang_init(void)
 
 void new_bang(int x, int y, int z, int type, int owner, int c)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)owner;
+    stkargs[1] = (int)(intptr_t)c;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_new_bang\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (type), "g" (owner), "g" (c));
+        : : "a" (x), "d" (y), "b" (z), "c" (type), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void bang_new5(int x, int y, int z, int type, int owner)
@@ -91,11 +99,19 @@ void unused_func_025(short a1, short a2, short a3)
 
 void do_shockwave(int x, int y, int z, int radius, int intensity, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)intensity;
+    stkargs[1] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_do_shockwave\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (radius), "g" (intensity), "g" (p_owner));
+        : : "a" (x), "d" (y), "b" (z), "c" (radius), "r" (stkargs)
+        : "cc", "memory");
 }
 
 
@@ -109,30 +125,54 @@ void do_shockwave_building(int dist, int intensity, struct Thing *p_thing, struc
 void do_shockwave_vehicle(int dx, int dz, int dist, int intensity,
   struct Thing *p_vevicle, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)p_vevicle;
+    stkargs[1] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_do_shockwave_vehicle\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "g" (p_vevicle), "g" (p_owner));
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void do_shockwave_person(int dx, int dz, int dist, int intensity,
   struct Thing *p_person, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)p_person;
+    stkargs[1] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_do_shockwave_person\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "g" (p_person), "g" (p_owner));
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void do_shockwave_scale_effect(int dx, int dz, int dist, int intensity,
   struct SimpleThing *p_sthing, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)p_sthing;
+    stkargs[1] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_do_shockwave_scale_effect\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "g" (p_sthing), "g" (p_owner));
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : "cc", "memory");
 }
 /******************************************************************************/

--- a/src/building.c
+++ b/src/building.c
@@ -140,11 +140,20 @@ TbBool building_can_transform_open(ThingIdx bldng)
 struct Thing *create_building_thing(int x, int y, int z, ushort obj, ushort nobj, ushort a6)
 {
     struct Thing *ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)nobj;
+    stkargs[1] = (int)(intptr_t)a6;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_create_building_thing\n"
-        : "=r" (ret) : "a" (x), "d" (y), "b" (z), "c" (obj), "g" (nobj), "g" (a6));
+        : "=r" (ret)
+        : "a" (x), "d" (y), "b" (z), "c" (obj), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 
@@ -554,11 +563,19 @@ void process_shuttle_loader(struct Thing *p_building)
 
 void bul_hit_vector(int x, int y, int z, short col, int hp, int type)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)hp;
+    stkargs[1] = (int)(intptr_t)type;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_bul_hit_vector\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (col), "g" (hp), "g" (type));
+        : : "a" (x), "d" (y), "b" (z), "c" (col), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void rotate_object(struct Thing *p_object)
@@ -570,11 +587,20 @@ void rotate_object(struct Thing *p_object)
 int mounted_los(int x1, int y1, int z1, int x2, int y2, int z2)
 {
     int ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_mounted_los\n"
-        : "=r" (ret) : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2));
+        : "=r" (ret)
+        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 

--- a/src/game.c
+++ b/src/game.c
@@ -1444,12 +1444,21 @@ void draw_hud(int dcthing)
 
 void func_6fd1c(int a1, int a2, int a3, int a4, int a5, int a6, ubyte a7)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)a5;
+    stkargs[1] = (int)(intptr_t)a6;
+    stkargs[2] = (int)(intptr_t)a7;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_func_6fd1c\n"
-        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "g" (a5), "g" (a6), "g" (a7));
+        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void draw_engine_net_text(void)

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -1570,11 +1570,19 @@ void draw_agent_grouping_bars(short panel)
 
 void func_702c0(int a1, int a2, int a3, int a4, int a5, ubyte a6)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)a5;
+    stkargs[1] = (int)(intptr_t)a6;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_func_702c0\n"
-        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "g" (a5), "g" (a6));
+        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void draw_transparent_slant_bar(short x, short y, ushort w, ushort h)

--- a/src/lvobjctv.c
+++ b/src/lvobjctv.c
@@ -811,12 +811,22 @@ ubyte mem_group_arrived_square2(struct Thing *p_person, ushort group, short x, s
   int x2, int z2, int count)
 {
     ubyte ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)x2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)count;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_mem_group_arrived_square2\n"
-        : "=r" (ret) : "a" (p_person), "d" (group), "b" (x), "c" (z), "g" (x2), "g" (z2), "g" (count));
+        : "=r" (ret)
+        : "a" (p_person), "d" (group), "b" (x), "c" (z), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 
@@ -824,11 +834,20 @@ ubyte mem_group_arrived(ushort group, short x, short y, short z,
   int radius, int count)
 {
     ubyte ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)radius;
+    stkargs[1] = (int)(intptr_t)count;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_mem_group_arrived\n"
-        : "=r" (ret) : "a" (group), "d" (x), "b" (y), "c" (z), "g" (radius), "g" (count));
+        : "=r" (ret)
+        : "a" (group), "d" (x), "b" (y), "c" (z), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 

--- a/src/pathtrig.c
+++ b/src/pathtrig.c
@@ -90,11 +90,19 @@ int unkn_path_func_001(struct Thing *p_thing, ubyte a2)
 
 void path_init8_unkn3(struct Path *path, int ax8, int ay8, int bx8, int by8, int a6)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)by8;
+    stkargs[1] = (int)(intptr_t)a6;
+
     asm volatile (
-      "push %5\n"
-      "push %4\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_path_init8_unkn3\n"
-        : : "a" (path), "d" (ax8), "b" (ay8), "c" (bx8), "g" (by8), "g" (a6));
+        : : "a" (path), "d" (ax8), "b" (ay8), "c" (bx8), "r" (stkargs)
+        : "cc", "memory");
 }
 
 //TODO temp copy of static func
@@ -302,24 +310,44 @@ void make_edge(int x1, int y1, int x2, int y2)
 int edge_find(int x1, int y1, int x2, int y2, int *ntri1, int *ncor1)
 {
     int ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)ntri1;
+    stkargs[1] = (int)(intptr_t)ncor1;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_edge_find\n"
-        : "=r" (ret) : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "g" (ntri1), "g" (ncor1));
+        : "=r" (ret)
+        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 
 TbBool two4_line_intersection(int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
 {
     TbBool ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)x3;
+    stkargs[1] = (int)(intptr_t)y3;
+    stkargs[2] = (int)(intptr_t)x4;
+    stkargs[3] = (int)(intptr_t)y4;
+
     asm volatile (
-      "push %8\n"
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 12(%5)\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_two4_line_intersection\n"
-        : "=r" (ret) : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "g" (x3), "g" (y3), "g" (x4), "g" (y4));
+        : "=r" (ret)
+        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 

--- a/src/purpldrw.c
+++ b/src/purpldrw.c
@@ -1497,12 +1497,21 @@ ubyte info_box_text(struct ScreenInfoBox *p_box)
 
 void draw_triangle_purple_list(int x1, int y1, int x2, int y2, int x3, int y3, TbPixel colour)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)x3;
+    stkargs[1] = (int)(intptr_t)y3;
+    stkargs[2] = (int)(intptr_t)colour;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_draw_triangle_purple_list\n"
-        : : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "g" (x3), "g" (y3), "g" (colour));
+        : : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void draw_flic_purple_list(void (*fn)())

--- a/src/sound.c
+++ b/src/sound.c
@@ -98,12 +98,22 @@ struct SampleInfo *play_sample_using_heap(ulong bank_id, short smptbl_id,
   ulong volume, ulong pan, ulong pitch, sbyte loop_count, ubyte type)
 {
     struct SampleInfo *ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)pitch;
+    stkargs[1] = (int)(intptr_t)loop_count;
+    stkargs[2] = (int)(intptr_t)type;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_play_sample_using_heap\n"
-        : "=r" (ret) : "a" (bank_id), "d" (smptbl_id), "b" (volume), "c" (pan), "g" (pitch), "g" (loop_count), "g" (type));
+        : "=r" (ret)
+        : "a" (bank_id), "d" (smptbl_id), "b" (volume), "c" (pan), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 
@@ -131,22 +141,40 @@ void play_disk_sample(short id, ushort sample, short vol, short pan, int pitch, 
 
 void play_dist_sample(struct Thing *p_thing, ushort smptbl_id, ushort vol, ushort pan, int pitch, int loop, ubyte type)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)pitch;
+    stkargs[1] = (int)(intptr_t)loop;
+    stkargs[2] = (int)(intptr_t)type;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_play_dist_sample\n"
-        : : "a" (p_thing), "d" (smptbl_id), "b" (vol), "c" (pan), "g" (pitch), "g" (loop), "g" (type));
+        : : "a" (p_thing), "d" (smptbl_id), "b" (vol), "c" (pan), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void play_dist_ssample(struct SimpleThing *p_sthing, ushort smptbl_id, ushort vol, ushort pan, int pitch, int loop, ubyte type)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)pitch;
+    stkargs[1] = (int)(intptr_t)loop;
+    stkargs[2] = (int)(intptr_t)type;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_play_dist_ssample\n"
-        : : "a" (p_sthing), "d" (smptbl_id), "b" (vol), "c" (pan), "g" (pitch), "g" (loop), "g" (type));
+        : : "a" (p_sthing), "d" (smptbl_id), "b" (vol), "c" (pan), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void stop_looped_weapon_sample(struct Thing *p_person, short weapon)

--- a/src/thing.c
+++ b/src/thing.c
@@ -1930,11 +1930,20 @@ struct SimpleThing *create_scale_effect(int x, int y, int z, ushort frame, short
 struct SimpleThing *create_sound_effect(int x, int y, int z, ushort sample, int vol, int loop)
 {
     struct SimpleThing *ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[2];
+
+    stkargs[0] = (int)(intptr_t)vol;
+    stkargs[1] = (int)(intptr_t)loop;
+
     asm volatile (
-      "push %6\n"
-      "push %5\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_create_sound_effect\n"
-        : "=r" (ret) : "a" (x), "d" (y), "b" (z), "c" (sample), "g" (vol), "g" (loop));
+        : "=r" (ret)
+        : "a" (x), "d" (y), "b" (z), "c" (sample), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 
@@ -1992,12 +2001,22 @@ struct SimpleThing *create_electric_strand(MapCoord x, MapCoord y, MapCoord z,
 {
 #if 1
     struct SimpleThing *ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)sound;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_create_electric_strand\n"
-        : "=r" (ret) : "a" (x), "d" (y), "b" (z), "c" (x2), "g" (y2), "g" (z2), "g" (sound));
+        : "=r" (ret)
+        : "a" (x), "d" (y), "b" (z), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 #endif
 }

--- a/src/thing_onface.c
+++ b/src/thing_onface.c
@@ -43,13 +43,24 @@ extern struct Thing thing_on_face;
 ubyte check_big_point_triangle(int x, int y, int ux, int uy, int vx, int vy, int wx, int wy)
 {
     ubyte ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)vx;
+    stkargs[1] = (int)(intptr_t)vy;
+    stkargs[2] = (int)(intptr_t)wx;
+    stkargs[3] = (int)(intptr_t)wy;
+
     asm volatile (
-      "push %8\n"
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 12(%5)\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_check_big_point_triangle\n"
-        : "=r" (ret) : "a" (x), "d" (y), "b" (ux), "c" (uy), "g" (vx), "g" (vy), "g" (wx), "g" (wy));
+        : "=r" (ret)
+        : "a" (x), "d" (y), "b" (ux), "c" (uy), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 

--- a/src/thing_search.c
+++ b/src/thing_search.c
@@ -1083,12 +1083,22 @@ short find_nearest_person_min(int x, int y, int z,
   int n_dist, int *a_dist, int angle1, u32 group_bits)
 {
     short ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)a_dist;
+    stkargs[1] = (int)(intptr_t)angle1;
+    stkargs[2] = (int)(intptr_t)group_bits;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_find_nearest_person_min\n"
-        : "=r" (ret) : "a" (x), "d" (y), "b" (z), "c" (n_dist), "g" (a_dist), "g" (angle1), "g" (group_bits));
+        : "=r" (ret)
+        : "a" (x), "d" (y), "b" (z), "c" (n_dist), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 

--- a/src/tngobjdrw.c
+++ b/src/tngobjdrw.c
@@ -572,13 +572,23 @@ void build_unkn18(struct Thing *p_thing)
 
 void build_electricity(int x1, int y1, int z1, int x2, int y2, int z2, int itime, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)itime;
+    stkargs[3] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 12(%4)\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_build_electricity\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (itime), "g" (p_owner));
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void build_laser_elec(struct Thing *p_thing)
@@ -637,24 +647,44 @@ void build_nuclear_bomb(struct SimpleThing *p_sthing)
 
 void build_laser_beam(int x1, int y1, int z1, int x2, int y2, int z2, int itime, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)itime;
+    stkargs[3] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 12(%4)\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_build_laser_beam\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (itime), "g" (p_owner));
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void build_laser_beam_q(int x1, int y1, int z1, int x2, int y2, int z2, int itime, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)itime;
+    stkargs[3] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 12(%4)\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_build_laser_beam_q\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (itime), "g" (p_owner));
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void build_laser29(struct Thing *p_thing)
@@ -679,13 +709,23 @@ void build_electricity_strand(struct SimpleThing *p_sthing, ubyte itime)
 
 void build_razor_wire_strand(int x1, int y1, int z1, int x2, int y2, int z2, int itime, struct Thing *p_owner)
 {
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[4];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)itime;
+    stkargs[3] = (int)(intptr_t)p_owner;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
-      "push %4\n"
+      "push 12(%4)\n"
+      "push 8(%4)\n"
+      "push 4(%4)\n"
+      "push 0(%4)\n"
       "call ASM_build_razor_wire_strand\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (itime), "g" (p_owner));
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
 }
 
 void build_soul(struct SimpleThing *p_sthing)

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -5243,12 +5243,22 @@ void process_weapon(struct Thing *p_person)
 s32 laser_hit_at(s32 x1, s32 y1, s32 z1, s32 *x2, s32 *y2, s32 *z2, struct Thing *p_shot)
 {
     s32 ret;
+    // Pushed through a register holding them: a "g" operand may be placed
+    // relative to the stack pointer, which each push moves.
+    int stkargs[3];
+
+    stkargs[0] = (int)(intptr_t)y2;
+    stkargs[1] = (int)(intptr_t)z2;
+    stkargs[2] = (int)(intptr_t)p_shot;
+
     asm volatile (
-      "push %7\n"
-      "push %6\n"
-      "push %5\n"
+      "push 8(%5)\n"
+      "push 4(%5)\n"
+      "push 0(%5)\n"
       "call ASM_laser_hit_at\n"
-        : "=r" (ret) : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "g" (y2), "g" (z2), "g" (p_shot));
+        : "=r" (ret)
+        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "cc", "memory");
     return ret;
 }
 


### PR DESCRIPTION
Towards #413. Same defect #424 fixed in `bul_path_end()`, and the same fix,
applied everywhere the pattern occurs.

You put the count at 45 on #424 with `grep '"g".*"g"' src/*.c`. Going through
them: **28 are live code**, the other fifteen sit inside `#if 0`. Those are
left alone.

## Why it breaks

`"g"` allows a memory operand and the base register is the compiler's choice.
Unoptimised it picks the frame pointer, which the pushes do not move, so each
push reads the slot it means to. Optimised it may pick the stack pointer,
which every push moves by four - so from the second push on, the wrong slot is
read and the callee is handed something that is not its argument.

## The fix

The stack arguments are gathered into a small array first and pushed through a
register holding its address. That register does not move, so the pushes stay
correct however the operands were placed. The four register arguments are
untouched at every site; only the stack ones change.

## What it fixes

Two crashes I could reach, both segfaults inside the assembly, both reading
through an argument that was never theirs:

- `ASM_do_shockwave_person`, on mission 1 of the first campaign - this one
  goes off almost at once;
- `ASM_laser_hit_at`, reached from `mem_group_arrived_square2`, on mission 5.

Built with `CFLAGS="-m32 -fPIC -O2"` and run headless through missions 1, 3, 5,
7 and 9 of the first campaign, forty seconds each. Before this change three of
the five segfaulted; after it, none did, and `error.log` stays clean.

The seven bflibrary tests are untouched by this and still pass.

## What this is not

It is not the `"=r"` audit from #412 - I have left those constraints exactly as
they were, including on the sites this touches. That one is still beyond what I
can take on, and I said so on #413. This is only the push-through-register
change, which is mechanical and has one shape.

Nor does it change any build file. Whether the README and the CI move to `-O2`
is your call and belongs on #413; I have measurements there.
