### PR TITLE
Ask for a register which cannot be the stack pointer

### DIFF
--- a/src/bmbang.c
+++ b/src/bmbang.c
@@ -50,7 +50,7 @@ void new_bang(int x, int y, int z, int type, int owner, int c)
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_new_bang\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (type), "r" (stkargs)
+        : : "a" (x), "d" (y), "b" (z), "c" (type), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -110,7 +110,7 @@ void do_shockwave(int x, int y, int z, int radius, int intensity, struct Thing *
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_do_shockwave\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (radius), "r" (stkargs)
+        : : "a" (x), "d" (y), "b" (z), "c" (radius), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -136,7 +136,7 @@ void do_shockwave_vehicle(int dx, int dz, int dist, int intensity,
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_do_shockwave_vehicle\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -154,7 +154,7 @@ void do_shockwave_person(int dx, int dz, int dist, int intensity,
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_do_shockwave_person\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -172,7 +172,7 @@ void do_shockwave_scale_effect(int dx, int dz, int dist, int intensity,
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_do_shockwave_scale_effect\n"
-        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "r" (stkargs)
+        : : "a" (dx), "d" (dz), "b" (dist), "c" (intensity), "S" (stkargs)
         : "cc", "memory");
 }
 /******************************************************************************/

--- a/src/building.c
+++ b/src/building.c
@@ -152,7 +152,7 @@ struct Thing *create_building_thing(int x, int y, int z, ushort obj, ushort nobj
       "push 0(%5)\n"
       "call ASM_create_building_thing\n"
         : "=r" (ret)
-        : "a" (x), "d" (y), "b" (z), "c" (obj), "r" (stkargs)
+        : "a" (x), "d" (y), "b" (z), "c" (obj), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -574,7 +574,7 @@ void bul_hit_vector(int x, int y, int z, short col, int hp, int type)
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_bul_hit_vector\n"
-        : : "a" (x), "d" (y), "b" (z), "c" (col), "r" (stkargs)
+        : : "a" (x), "d" (y), "b" (z), "c" (col), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -599,7 +599,7 @@ int mounted_los(int x1, int y1, int z1, int x2, int y2, int z2)
       "push 0(%5)\n"
       "call ASM_mounted_los\n"
         : "=r" (ret)
-        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }

--- a/src/game.c
+++ b/src/game.c
@@ -1457,7 +1457,7 @@ void func_6fd1c(int a1, int a2, int a3, int a4, int a5, int a6, ubyte a7)
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_func_6fd1c\n"
-        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "r" (stkargs)
+        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "S" (stkargs)
         : "cc", "memory");
 }
 

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -1581,7 +1581,7 @@ void func_702c0(int a1, int a2, int a3, int a4, int a5, ubyte a6)
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_func_702c0\n"
-        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "r" (stkargs)
+        : : "a" (a1), "d" (a2), "b" (a3), "c" (a4), "S" (stkargs)
         : "cc", "memory");
 }
 

--- a/src/lvobjctv.c
+++ b/src/lvobjctv.c
@@ -825,7 +825,7 @@ ubyte mem_group_arrived_square2(struct Thing *p_person, ushort group, short x, s
       "push 0(%5)\n"
       "call ASM_mem_group_arrived_square2\n"
         : "=r" (ret)
-        : "a" (p_person), "d" (group), "b" (x), "c" (z), "r" (stkargs)
+        : "a" (p_person), "d" (group), "b" (x), "c" (z), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -846,7 +846,7 @@ ubyte mem_group_arrived(ushort group, short x, short y, short z,
       "push 0(%5)\n"
       "call ASM_mem_group_arrived\n"
         : "=r" (ret)
-        : "a" (group), "d" (x), "b" (y), "c" (z), "r" (stkargs)
+        : "a" (group), "d" (x), "b" (y), "c" (z), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }

--- a/src/pathtrig.c
+++ b/src/pathtrig.c
@@ -101,7 +101,7 @@ void path_init8_unkn3(struct Path *path, int ax8, int ay8, int bx8, int by8, int
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_path_init8_unkn3\n"
-        : : "a" (path), "d" (ax8), "b" (ay8), "c" (bx8), "r" (stkargs)
+        : : "a" (path), "d" (ax8), "b" (ay8), "c" (bx8), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -322,7 +322,7 @@ int edge_find(int x1, int y1, int x2, int y2, int *ntri1, int *ncor1)
       "push 0(%5)\n"
       "call ASM_edge_find\n"
         : "=r" (ret)
-        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -346,7 +346,7 @@ TbBool two4_line_intersection(int x1, int y1, int x2, int y2, int x3, int y3, in
       "push 0(%5)\n"
       "call ASM_two4_line_intersection\n"
         : "=r" (ret)
-        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }

--- a/src/purpldrw.c
+++ b/src/purpldrw.c
@@ -1510,7 +1510,7 @@ void draw_triangle_purple_list(int x1, int y1, int x2, int y2, int x3, int y3, T
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_draw_triangle_purple_list\n"
-        : : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "r" (stkargs)
+        : : "a" (x1), "d" (y1), "b" (x2), "c" (y2), "S" (stkargs)
         : "cc", "memory");
 }
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -112,7 +112,7 @@ struct SampleInfo *play_sample_using_heap(ulong bank_id, short smptbl_id,
       "push 0(%5)\n"
       "call ASM_play_sample_using_heap\n"
         : "=r" (ret)
-        : "a" (bank_id), "d" (smptbl_id), "b" (volume), "c" (pan), "r" (stkargs)
+        : "a" (bank_id), "d" (smptbl_id), "b" (volume), "c" (pan), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -154,7 +154,7 @@ void play_dist_sample(struct Thing *p_thing, ushort smptbl_id, ushort vol, ushor
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_play_dist_sample\n"
-        : : "a" (p_thing), "d" (smptbl_id), "b" (vol), "c" (pan), "r" (stkargs)
+        : : "a" (p_thing), "d" (smptbl_id), "b" (vol), "c" (pan), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -173,7 +173,7 @@ void play_dist_ssample(struct SimpleThing *p_sthing, ushort smptbl_id, ushort vo
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_play_dist_ssample\n"
-        : : "a" (p_sthing), "d" (smptbl_id), "b" (vol), "c" (pan), "r" (stkargs)
+        : : "a" (p_sthing), "d" (smptbl_id), "b" (vol), "c" (pan), "S" (stkargs)
         : "cc", "memory");
 }
 

--- a/src/thing.c
+++ b/src/thing.c
@@ -1942,7 +1942,7 @@ struct SimpleThing *create_sound_effect(int x, int y, int z, ushort sample, int 
       "push 0(%5)\n"
       "call ASM_create_sound_effect\n"
         : "=r" (ret)
-        : "a" (x), "d" (y), "b" (z), "c" (sample), "r" (stkargs)
+        : "a" (x), "d" (y), "b" (z), "c" (sample), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -2015,7 +2015,7 @@ struct SimpleThing *create_electric_strand(MapCoord x, MapCoord y, MapCoord z,
       "push 0(%5)\n"
       "call ASM_create_electric_strand\n"
         : "=r" (ret)
-        : "a" (x), "d" (y), "b" (z), "c" (x2), "r" (stkargs)
+        : "a" (x), "d" (y), "b" (z), "c" (x2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 #endif

--- a/src/thing_onface.c
+++ b/src/thing_onface.c
@@ -59,7 +59,7 @@ ubyte check_big_point_triangle(int x, int y, int ux, int uy, int vx, int vy, int
       "push 0(%5)\n"
       "call ASM_check_big_point_triangle\n"
         : "=r" (ret)
-        : "a" (x), "d" (y), "b" (ux), "c" (uy), "r" (stkargs)
+        : "a" (x), "d" (y), "b" (ux), "c" (uy), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }

--- a/src/thing_search.c
+++ b/src/thing_search.c
@@ -1097,7 +1097,7 @@ short find_nearest_person_min(int x, int y, int z,
       "push 0(%5)\n"
       "call ASM_find_nearest_person_min\n"
         : "=r" (ret)
-        : "a" (x), "d" (y), "b" (z), "c" (n_dist), "r" (stkargs)
+        : "a" (x), "d" (y), "b" (z), "c" (n_dist), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }

--- a/src/tngobjdrw.c
+++ b/src/tngobjdrw.c
@@ -587,7 +587,7 @@ void build_electricity(int x1, int y1, int z1, int x2, int y2, int z2, int itime
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_build_electricity\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -662,7 +662,7 @@ void build_laser_beam(int x1, int y1, int z1, int x2, int y2, int z2, int itime,
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_build_laser_beam\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -683,7 +683,7 @@ void build_laser_beam_q(int x1, int y1, int z1, int x2, int y2, int z2, int itim
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_build_laser_beam_q\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
 }
 
@@ -724,7 +724,7 @@ void build_razor_wire_strand(int x1, int y1, int z1, int x2, int y2, int z2, int
       "push 4(%4)\n"
       "push 0(%4)\n"
       "call ASM_build_razor_wire_strand\n"
-        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
 }
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1550,7 +1550,7 @@ int bul_path_end(int x1, int y1, int z1, int *x2, int *y2, int *z2,
       "push 0(%5)\n"
       "call ASM_bul_path_end\n"
         : "=a" (ret)
-        : "0" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "0" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }
@@ -5257,7 +5257,7 @@ s32 laser_hit_at(s32 x1, s32 y1, s32 z1, s32 *x2, s32 *y2, s32 *z2, struct Thing
       "push 0(%5)\n"
       "call ASM_laser_hit_at\n"
         : "=r" (ret)
-        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "r" (stkargs)
+        : "a" (x1), "d" (y1), "b" (z1), "c" (x2), "S" (stkargs)
         : "cc", "memory");
     return ret;
 }


### PR DESCRIPTION
This fixes a fault in #427, which I sent and you merged this morning. Sorry - the shape of the fix was right, the constraint was not.

## What is wrong

The converted blocks hand the address of the argument array to the template with an `"r"` constraint. On x86 that register class **includes `%esp`**, and the compiler is free to choose it. It does. Here is what gcc 15.2 makes of `laser_hit_at()` at `-O2`:

```
	push 8(%esp)
	push 4(%esp)
	push 0(%esp)
	call ASM_laser_hit_at
```

The offsets in the template were written on the assumption that the base register stands still. Every `push` moves `%esp`, so from the second one on they read the wrong slots:

| in the template | meant to push | actually pushed |
|---|---|---|
| `push 8(%5)` | `p_shot` | `p_shot` |
| `push 4(%5)` | `z2` | **`y2`** |
| `push 0(%5)` | `y2` | `y2` |

`ASM_laser_hit_at` then writes the Z coordinate of the shot through the pointer to Y. That is the same fault #424 and #427 were about, arriving by another door.

At `-O0` the compiler never picks `%esp` here - it keeps a frame pointer and addresses locals through `%ebp` - which is why none of this shows without optimisation.

Reading the generated assembly for the whole of `src/`: **at `-O2` gcc picks `%esp` in 9 of the 29 blocks; at `-O0`, in none.**

| file | routine called |
|---|---|
| `src/game.c` | `ASM_func_6fd1c` |
| `src/lvobjctv.c` | `ASM_mem_group_arrived_square2` |
| `src/purpldrw.c` | `ASM_draw_triangle_purple_list` |
| `src/sound.c` | `ASM_play_sample_using_heap` |
| `src/sound.c` | `ASM_play_dist_sample` |
| `src/sound.c` | `ASM_play_dist_ssample` |
| `src/thing.c` | `ASM_create_electric_strand` |
| `src/thing_search.c` | `ASM_find_nearest_person_min` |
| `src/weapon.c` | `ASM_laser_hit_at` |

Which nine you get is the register allocator's decision, so I would not expect another compiler, or another version, to land on the same set.

## The change

`"r" (stkargs)` becomes `"S" (stkargs)` at the 29 sites - the 28 from #427 plus `bul_path_end()` from #424. `%esi` cannot be `%esp`, and it is free at every one of these blocks, which only use `a`, `d`, `b` and `c`.

After the change no block is left with more than one push relative to `%esp`. Six still have exactly one, and those are correct: the read happens before the decrement.

## How it turned up, and what it is worth

I was trying to answer your question on #413, so I compared an `-O0` build and an `-O2` build of current master turn by turn: 16 missions of the first campaign, 200 game turns each, hashing the screen buffer and `lbSeed` every 20 turns. Fifteen were identical at every checkpoint. Mission 109 was not, reproducibly - the random stream parts company around turn 90 and the screen follows at turn 140. Bisecting the objects gave `weapon.c`, bisecting the functions gave `laser_hit_at()`, and changing that one constraint put it back.

| build | missions identical to `-O0` |
|---|---|
| master, `-O2` | 15 of 16 |
| this branch, `-O2` | **16 of 16** |

I also played the first mission through with this branch built with `-O2`, scrolling well around the map, and saw nothing unusual; `error.log` stayed empty.

Measured with gcc 15.2, 32-bit, on Linux, headless through Xvfb. Sixteen missions of two hundred turns is not the whole game, and I have not looked at what other compilers choose here.

One thing that may or may not be a coincidence: `ASM_draw_triangle_purple_list` is among the nine. A draw function receiving one wrong pointer among its coordinates is close to the artifacts you describe on Windows in #413.
