### PR TITLE
Swap the subscripts when copying FourPacks from a network player

### DIFF
--- a/src/packetfe.c
+++ b/src/packetfe.c
@@ -271,7 +271,7 @@ void agents_copy_fourpacks_netplayer_to_player(int plyr, struct NetworkPlayer *p
     for (plagent = 0; plagent < 4; plagent++)
     {
         for (fp = 0; fp < WFRPK_COUNT; fp++) {
-            players[plyr].FourPacks[plagent][fp] = \
+            players[plyr].FourPacks[fp][plagent] = \
               p_netplyr->U.FourPacks.FourPacks[plagent][fp];
         }
     }


### PR DESCRIPTION
`PlayerInfo.FourPacks` is declared `[WFRPK_COUNT][AGENTS_SQUAD_MAX_COUNT]`, weapon first and agent second, and every other use of it in the tree agrees - `player.c:67`, `fecryo.c:1178`, `hud_panel.c:812`, `game_save.c:742`. `agents_copy_fourpacks_netplayer_to_player()` was the only place with the two the other way round, so the loop ran off the second dimension once `fp` reached 4, and the entries it did write landed in the wrong slots.

The source side, `struct NetworkPlayerUFourPacks` declared `[4][5]`, was already correct and is untouched. So are the two neighbouring functions, which go through `cryo_agents.FourPacks[plagent].Amount[fp]` and read right to me.

This is the second of the two from #429. I have left the loop bounds and everything else alone, since these tables are still reached from assembly.

Built current master at `-O2` with gcc 15.2: `-Waggressive-loop-optimizations` fires on `packetfe.c:274` before the change and is gone after it. I also built it on Linux Mint with gcc 13 and played the first mission, which exercises none of this - network code is not reached in a single player game - so what I can offer is that nothing else moved.
