### PR TITLE
Shift the outro hot characters over seven entries, and name the array

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -838,11 +838,11 @@ void sub_CC554(void)
 {
     ushort i;
 
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < 8 - 1; i++)
     {
         LbMemoryCopy(&stru_1DDB70[i], &stru_1DDB70[i+1], sizeof(struct struc_CC638));
-        if (stru_1DDB70[i + 1].field_9 > 32)
-            stru_1DDB70[i + 1].field_9 -= 4;
+        if (stru_1DDB70[i].field_9 > 32)
+            stru_1DDB70[i].field_9 -= 4;
     }
     stru_1DDB70[8 - 1].field_8 = 0;
 }

--- a/src/game.c
+++ b/src/game.c
@@ -198,14 +198,20 @@ enum ReloadMenuFlags {
     RelMnuF_ScrBoxesFull = 0x04,
 };
 
+#define OUTRO_HOT_CHARS_COUNT 8
+
 #pragma pack(1)
 
-struct struc_CC638 {
-    s32 field_0;
-    s32 field_4;
-    ubyte field_8;
-    ubyte field_9;
-    ubyte field_A;
+/** A character of the outro text which was already drawn, and is still
+ * bright enough to be worth drawing again while it fades out. */
+struct OutroHotChar {
+    s32 x;
+    s32 y;
+    ubyte chr;
+    /** Brightness, used as index within pixmap.fade_table[]. */
+    ubyte fade_lv;
+    /** Font to draw with; 1 selects big_font, anything else med2_font. */
+    ubyte font;
     ubyte field_B;
 };
 
@@ -291,7 +297,7 @@ extern long mech_unkn_tile_y2;
 extern long mech_unkn_tile_x3;
 extern long mech_unkn_tile_y3;
 
-extern struct struc_CC638 stru_1DDB70[8];
+extern struct OutroHotChar outro_hot_chars[OUTRO_HOT_CHARS_COUNT];
 
 //TODO this is not an extern only because I was unable to locate it in asm
 ushort next_bezier_pt = 1;
@@ -838,13 +844,13 @@ void sub_CC554(void)
 {
     ushort i;
 
-    for (i = 0; i < 8 - 1; i++)
+    for (i = 0; i < OUTRO_HOT_CHARS_COUNT - 1; i++)
     {
-        LbMemoryCopy(&stru_1DDB70[i], &stru_1DDB70[i+1], sizeof(struct struc_CC638));
-        if (stru_1DDB70[i].field_9 > 32)
-            stru_1DDB70[i].field_9 -= 4;
+        LbMemoryCopy(&outro_hot_chars[i], &outro_hot_chars[i+1], sizeof(struct OutroHotChar));
+        if (outro_hot_chars[i].fade_lv > 32)
+            outro_hot_chars[i].fade_lv -= 4;
     }
-    stru_1DDB70[8 - 1].field_8 = 0;
+    outro_hot_chars[OUTRO_HOT_CHARS_COUNT - 1].chr = 0;
 }
 
 char func_cc638(const char *text1, const char *text2)

--- a/src/swars.sx
+++ b/src/swars.sx
@@ -129728,7 +129728,7 @@ func_cc59c:
 		jmp    jump_cc5d6
 	jump_cc5a5:
 		xor    %ecx,%ecx
-		mov    EXPORT_SYMBOL(stru_1DDB70)+0x08(%esi),%cl
+		mov    EXPORT_SYMBOL(outro_hot_chars)+0x08(%esi),%cl
 		imul   $0x6,%ecx,%ecx
 		mov    EXPORT_SYMBOL(med2_font),%ebx
 	jump_cc5b6:
@@ -129743,17 +129743,17 @@ func_cc59c:
 		cmp    $0x60,%esi
 		je     jump_cc612
 	jump_cc5d6:
-		cmpb   $0x0,EXPORT_SYMBOL(stru_1DDB70)+0x08(%esi)
+		cmpb   $0x0,EXPORT_SYMBOL(outro_hot_chars)+0x08(%esi)
 		je     jump_cc5ce
-		mov    EXPORT_SYMBOL(stru_1DDB70)(%esi),%eax
+		mov    EXPORT_SYMBOL(outro_hot_chars)(%esi),%eax
 		xor    %ebx,%ebx
-		mov    EXPORT_SYMBOL(stru_1DDB70)+0x04(%esi),%edx
-		mov    EXPORT_SYMBOL(stru_1DDB70)+0x0A(%esi),%bl
-		movzbl EXPORT_SYMBOL(stru_1DDB70)+0x09(%esi),%edi
+		mov    EXPORT_SYMBOL(outro_hot_chars)+0x04(%esi),%edx
+		mov    EXPORT_SYMBOL(outro_hot_chars)+0x0A(%esi),%bl
+		movzbl EXPORT_SYMBOL(outro_hot_chars)+0x09(%esi),%edi
 		cmp    $0x1,%ebx
 		jne    jump_cc5a5
 		xor    %ebx,%ebx
-		mov    EXPORT_SYMBOL(stru_1DDB70)+0x08(%esi),%bl
+		mov    EXPORT_SYMBOL(outro_hot_chars)+0x08(%esi),%bl
 		imul   $0x6,%ebx,%ebx
 		mov    EXPORT_SYMBOL(big_font),%ecx
 		jmp    jump_cc5b6
@@ -129793,7 +129793,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 	jump_cc647:
 		add    $0xc,%eax
 		xor    %dl,%dl
-		mov    %dl,EXPORT_SYMBOL(stru_1DDB70)-0x04(%eax)
+		mov    %dl,EXPORT_SYMBOL(outro_hot_chars)-0x04(%eax)
 		cmp    $0x60,%eax
 		jne    jump_cc647
 		mov    $0xe,%edx
@@ -129805,20 +129805,20 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		je     jump_cc709
 	jump_cc671:
 		mov    0x0(%ebp),%al
-		mov    %al,data_1ddbcc
+		mov    %al,EXPORT_SYMBOL(outro_hot_chars)+0x5C
 		xor    %eax,%eax
 		mov    0x0(%ebp),%al
 		imul   $0x6,%eax,%eax
 		mov    $0x1,%dh
 		mov    $0xe,%esi
-		mov    %dh,data_1ddbce
+		mov    %dh,EXPORT_SYMBOL(outro_hot_chars)+0x5E
 		mov    EXPORT_SYMBOL(big_font),%edx
 		mov    $0x3f,%cl
 		add    %edx,%eax
-		mov    %ebx,data_1ddbc4
+		mov    %ebx,EXPORT_SYMBOL(outro_hot_chars)+0x54
 		sub    $0xba,%eax
-		mov    %esi,data_1ddbc8
-		mov    %cl,data_1ddbcd
+		mov    %esi,EXPORT_SYMBOL(outro_hot_chars)+0x58
+		mov    %cl,EXPORT_SYMBOL(outro_hot_chars)+0x5D
 		mov    0x4(%eax),%al
 		and    $0xff,%eax
 		inc    %ebp
@@ -129831,22 +129831,22 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		cmp    $0x60,%eax
 		je     jump_cc6f7
 	jump_cc6ce:
-		lea    EXPORT_SYMBOL(stru_1DDB70)-0x0C(%eax),%edi
-		lea    EXPORT_SYMBOL(stru_1DDB70)(%eax),%esi
+		lea    EXPORT_SYMBOL(outro_hot_chars)-0x0C(%eax),%edi
+		lea    EXPORT_SYMBOL(outro_hot_chars)(%eax),%esi
 		xor    %edx,%edx
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
-		mov    EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax),%dl
+		mov    EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax),%dl
 		cmp    $0x20,%edx
 		jle    jump_cc6c6
 		mov    %dl,%ch
 		sub    $0x4,%ch
-		mov    %ch,EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax)
+		mov    %ch,EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax)
 		jmp    jump_cc6c6
 	jump_cc6f7:
 		xor    %cl,%cl
-		mov    %cl,data_1ddbcc
+		mov    %cl,EXPORT_SYMBOL(outro_hot_chars)+0x5C
 		cmpb   $0x0,0x0(%ebp)
 		jne    jump_cc671
 	jump_cc709:
@@ -129927,20 +129927,20 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		jmp    jump_cc863
 	jump_cc801:
 		mov    0x4(%esp),%eax
-		mov    %eax,data_1ddbc4
+		mov    %eax,EXPORT_SYMBOL(outro_hot_chars)+0x54
 		mov    0x8(%esp),%eax
-		mov    %eax,data_1ddbc8
+		mov    %eax,EXPORT_SYMBOL(outro_hot_chars)+0x58
 		xor    %eax,%eax
 		mov    %dl,%al
 		imul   $0x6,%eax,%eax
 		mov    $0x2,%cl
-		mov    %dl,data_1ddbcc
+		mov    %dl,EXPORT_SYMBOL(outro_hot_chars)+0x5C
 		mov    EXPORT_SYMBOL(med2_font),%edx
-		mov    %cl,data_1ddbce
+		mov    %cl,EXPORT_SYMBOL(outro_hot_chars)+0x5E
 		add    %edx,%eax
 		mov    $0x3f,%ch
 		sub    $0xba,%eax
-		mov    %ch,data_1ddbcd
+		mov    %ch,EXPORT_SYMBOL(outro_hot_chars)+0x5D
 		mov    0x4(%eax),%al
 		mov    0x4(%esp),%edi
 		and    $0xff,%eax
@@ -129955,22 +129955,22 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		cmp    $0x60,%eax
 		je     jump_cc88c
 	jump_cc863:
-		lea    EXPORT_SYMBOL(stru_1DDB70)-0x0C(%eax),%edi
-		lea    EXPORT_SYMBOL(stru_1DDB70)(%eax),%esi
+		lea    EXPORT_SYMBOL(outro_hot_chars)-0x0C(%eax),%edi
+		lea    EXPORT_SYMBOL(outro_hot_chars)(%eax),%esi
 		xor    %edx,%edx
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
-		mov    EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax),%dl
+		mov    EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax),%dl
 		cmp    $0x20,%edx
 		jle    jump_cc85b
 		mov    %dl,%ch
 		sub    $0x4,%ch
-		mov    %ch,EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax)
+		mov    %ch,EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax)
 		jmp    jump_cc85b
 	jump_cc88c:
 		xor    %al,%al
-		mov    %al,data_1ddbcc
+		mov    %al,EXPORT_SYMBOL(outro_hot_chars)+0x5C
 		mov    0x1(%ebp),%ah
 		inc    %ebp
 		test   %ah,%ah
@@ -129985,7 +129985,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 	jump_cc8b1:
 		xor    %al,%al
 		inc    %ebx
-		mov    %al,data_1ddbcc
+		mov    %al,EXPORT_SYMBOL(outro_hot_chars)+0x5C
 		cmp    $0x8,%ebx
 		jge    jump_cc8f5
 		call   func_cc59c
@@ -129996,17 +129996,17 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		cmp    $0x60,%eax
 		je     jump_cc8b1
 	jump_cc8cf:
-		lea    EXPORT_SYMBOL(stru_1DDB70)-0x0C(%eax),%edi
-		lea    EXPORT_SYMBOL(stru_1DDB70)(%eax),%esi
+		lea    EXPORT_SYMBOL(outro_hot_chars)-0x0C(%eax),%edi
+		lea    EXPORT_SYMBOL(outro_hot_chars)(%eax),%esi
 		xor    %edx,%edx
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
 		movsl  %ds:(%esi),%es:(%edi)
-		mov    EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax),%dl
+		mov    EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax),%dl
 		cmp    $0x20,%edx
 		jle    jump_cc8c7
 		sub    %cl,%dl
-		mov    %dl,EXPORT_SYMBOL(stru_1DDB70)-0x03(%eax)
+		mov    %dl,EXPORT_SYMBOL(outro_hot_chars)-0x03(%eax)
 		jmp    jump_cc8c7
 	jump_cc8f5:
 		add    $0xc,%esp
@@ -133499,15 +133499,5 @@ data_1ddb6c:
 		.long	0x0
 		.align	4
 
-GLOBAL (stru_1DDB70)	/* 0x1ddb70 */
-		.fill   0x54
-data_1ddbc4:
-		.long	0x0
-data_1ddbc8:
-		.long	0x0
-data_1ddbcc:
-		.byte	0x0
-data_1ddbcd:
-		.byte	0x0
-data_1ddbce:
-		.short  0x0
+GLOBAL (outro_hot_chars)	/* 0x1ddb70 */
+		.fill   0x60


### PR DESCRIPTION
Follows from #429. Two commits, so the first can go in alone if the second is not to your taste.

**The loop.** `sub_CC554()` now runs seven times instead of eight, and decrements `field_9` of the destination entry rather than `[i+1]`, as we worked out on the issue. Nothing calls the function yet, so nothing changes on screen today; what does change is that `gcc -O2` stops reporting `iteration 7 invokes undefined behavior` on `game.c:844`.

**The name.** I took your reading of it. The array is touched only by `ASM_func_cc638()` and by `func_cc59c()` which it calls: each pass writes the character just drawn into the last entry with `field_9` at 0x3F, shifts the rest down one, and redraws all eight through `pixmap.fade_table` at their own brightness. So the eight entries are the tail of characters still fading behind the writing position - `outro_hot_chars[]`, with `OUTRO_HOT_CHARS_COUNT` for the eight.

The fields follow from the same two functions:

| was | now | why |
|---|---|---|
| `field_0`, `field_4` | `x`, `y` | the pair handed to `LbSpriteDrawRemap()` |
| `field_8` | `chr` | the character; zero means the slot is empty |
| `field_9` | `fade_lv` | index into `pixmap.fade_table`, 0x3F at birth, less 4 per pass, floor 32 |
| `field_A` | `font` | 1 selects `big_font`, anything else `med2_font` |
| `field_B` | unchanged | never read, never written |

**The eighth entry.** The five labels are gone and the assembly reaches those bytes through the main symbol, the same way `SCANNER_bbpadds` was handled in 05a8603a; `.fill` goes from 0x54 to 0x60. Thirteen references moved.

Checked rather than assumed: assembling `swars.sx` before and after gives a symbol table identical apart from the five removed labels - `outro_hot_chars` sits at the same offset `stru_1DDB70` did, and every symbol after it is unmoved - and `.text` and `.data` keep byte-for-byte the same sizes. Built at `-O2` on Linux, and one mission run headless for three minutes without trouble, though that exercises none of this.

I left the function named `sub_CC554`, since that address is not in `swars.sx` yet and the name still points somewhere useful. Say the word if you would rather it were named too.
