### PR TITLE
Name sub_CC554() after what it does, and point at its inlines

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -840,7 +840,7 @@ void play_intro(void)
     }
 }
 
-void sub_CC554(void)
+void outro_hot_chars_shift(void)
 {
     ushort i;
 

--- a/src/swars.sx
+++ b/src/swars.sx
@@ -129826,7 +129826,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		call   func_cc59c
 		mov    $0xc,%eax
 		jmp    jump_cc6ce
-	jump_cc6c6:
+	jump_cc6c6: /* inlined outro_hot_chars_shift() */
 		add    $0xc,%eax
 		cmp    $0x60,%eax
 		je     jump_cc6f7
@@ -129847,6 +129847,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 	jump_cc6f7:
 		xor    %cl,%cl
 		mov    %cl,EXPORT_SYMBOL(outro_hot_chars)+0x5C
+		/* end of inlined outro_hot_chars_shift() */
 		cmpb   $0x0,0x0(%ebp)
 		jne    jump_cc671
 	jump_cc709:
@@ -129950,7 +129951,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		call   func_cc59c
 		mov    $0xc,%eax
 		jmp    jump_cc863
-	jump_cc85b:
+	jump_cc85b: /* inlined outro_hot_chars_shift() */
 		add    $0xc,%eax
 		cmp    $0x60,%eax
 		je     jump_cc88c
@@ -129971,6 +129972,7 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 	jump_cc88c:
 		xor    %al,%al
 		mov    %al,EXPORT_SYMBOL(outro_hot_chars)+0x5C
+		/* end of inlined outro_hot_chars_shift() */
 		mov    0x1(%ebp),%ah
 		inc    %ebp
 		test   %ah,%ah
@@ -129986,12 +129988,13 @@ GLOBAL_FUNC (ASM_func_cc638)	/* 0xcc638 */
 		xor    %al,%al
 		inc    %ebx
 		mov    %al,EXPORT_SYMBOL(outro_hot_chars)+0x5C
+		/* end of inlined outro_hot_chars_shift() */
 		cmp    $0x8,%ebx
 		jge    jump_cc8f5
 		call   func_cc59c
 		mov    %ebp,%eax
 		jmp    jump_cc8cf
-	jump_cc8c7:
+	jump_cc8c7: /* inlined outro_hot_chars_shift() */
 		add    $0xc,%eax
 		cmp    $0x60,%eax
 		je     jump_cc8b1


### PR DESCRIPTION
Follows on from #431.

You said the rename was fine, so here it is. `outro_hot_chars_shift()`:
it shifts the array down one entry and fades what it keeps.

The three inlines you pointed at are marked in `swars.sx`, on the loop
head and again on the store which clears the last entry, so the shape of
the function is visible at each site:

```
	jump_cc6c6: /* inlined outro_hot_chars_shift() */
	...
		mov    %cl,EXPORT_SYMBOL(outro_hot_chars)+0x5C
		/* end of inlined outro_hot_chars_shift() */
```

The third one is the fade-out loop at the end, which keeps its `0xc` and
its `4` in registers rather than as immediates, but is otherwise the
same function.

Nothing else moved: strip the comments back out of `swars.sx` and the
file is identical to master, line for line. Built at `-O2` on Linux.