### PR TITLE
The render clock, and reading wobbly surfaces between turns

### DIFF
--- a/src/engindrwlstm_wrp.c
+++ b/src/engindrwlstm_wrp.c
@@ -239,7 +239,7 @@ void draw_pers_e_graphic(struct Thing *p_thing,
     br_inc = person_shield_glow_brightness(p_thing);
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[render_anim_turn & 0x1F] >> 3;
+        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
 
     transform_shpoint(&sp, cor_dx, 8 * cor_dy - 8 * engn_yc, cor_dz);
 
@@ -767,7 +767,7 @@ int draw_rot_object(int cor_dx, int cor_dy, int cor_dz,
     assert((p_thing->U.UObject.MatrixIndex < next_local_mat) || (p_thing->Type == TT_ROCKET));
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[render_anim_turn & 0x1F];
+        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
 
     object_points_clear_flags(point_object);
 
@@ -827,7 +827,7 @@ short draw_object_faces(int cor_dx, int cor_dy, int cor_dz,
 
     if ((point_object->field_1C & 0x0100) != 0 &&
       ((doflags & DrwObjF_NoWobblyElevation) == 0))
-        cor_dy += waft_table[render_anim_turn & 0x1F];
+        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
 
     bckt_max = 0;
 

--- a/src/engindrwlstm_wrp.c
+++ b/src/engindrwlstm_wrp.c
@@ -239,7 +239,7 @@ void draw_pers_e_graphic(struct Thing *p_thing,
     br_inc = person_shield_glow_brightness(p_thing);
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
+        cor_dy += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, cor_dx, 8 * cor_dy - 8 * engn_yc, cor_dz);
 
@@ -767,7 +767,7 @@ int draw_rot_object(int cor_dx, int cor_dy, int cor_dz,
     assert((p_thing->U.UObject.MatrixIndex < next_local_mat) || (p_thing->Type == TT_ROCKET));
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
+        cor_dy += waft_between_turns(render_anim_turn);
 
     object_points_clear_flags(point_object);
 
@@ -827,7 +827,7 @@ short draw_object_faces(int cor_dx, int cor_dy, int cor_dz,
 
     if ((point_object->field_1C & 0x0100) != 0 &&
       ((doflags & DrwObjF_NoWobblyElevation) == 0))
-        cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
+        cor_dy += waft_between_turns(render_anim_turn);
 
     bckt_max = 0;
 

--- a/src/engindrwlstx_tng.c
+++ b/src/engindrwlstx_tng.c
@@ -90,14 +90,14 @@ ushort number_player_get_frame(struct Thing *p_person, ubyte n)
         p_locplayer = &players[local_player_no];
         if (p_locplayer->DoubleMode == 0)
         {
-            if ((p_person->ThingOffset != (ThingIdx)p_locplayer->DirectControl[0]) || ((render_anim_turn & 4) != 0))
+            if ((p_person->ThingOffset != (ThingIdx)p_locplayer->DirectControl[0]) || (((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 4) != 0))
             {
                 frm = frame[frm].Next;
             }
             else
             {
                 ushort i;
-                for (i = 0; i <= (render_anim_turn & 3); i++)
+                for (i = 0; i <= ((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 3); i++)
                     frm = frame[frm].Next;
             }
         }

--- a/src/engintext.c
+++ b/src/engintext.c
@@ -26,6 +26,7 @@
 #include "app_text_cw.h"
 #include "app_text_sf.h"
 #include "engincolour.h"
+#include "enginprops.h"
 
 #include "game_sprts.h"
 #include "hud_panel.h"
@@ -103,7 +104,7 @@ void draw_text_linewrap1b(int base_x, int *p_pos_y, const char *text)
             const struct TbSprite *p_spr;
             ushort fade_lv;
 
-            fade_lv = 40 - (lbSinTable[128 * ((render_anim_turn + base_shift) & 0xF)] >> 13);
+            fade_lv = 40 - (lbSinTable[128 * (((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + base_shift) & 0xF)] >> 13);
             p_spr =  LbFontCharSprite(lbFontPtr, my_char_to_upper(*str));
             AppSpriteDrawDoubleOneColour(p_spr, pos_x + 1, pos_y + 1, colour_lookup[ColLU_BLACK]);
             AppSpriteDrawDoubleOneColour(p_spr, pos_x, pos_y, pixmap.fade_table[256 * fade_lv + col2]);
@@ -162,7 +163,7 @@ void draw_text_linewrap2b(int base_x, int *p_pos_y, const char *text)
             const struct TbSprite *p_spr;
             ushort fade_lv;
 
-            fade_lv = cw_base + cw_vari/2 - (cw_vari/2 * lbSinTable[LbFPMath_PI/8 * ((render_anim_turn + base_shift) & 0xF)] >> 16);
+            fade_lv = cw_base + cw_vari/2 - (cw_vari/2 * lbSinTable[LbFPMath_PI/8 * (((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + base_shift) & 0xF)] >> 16);
             p_spr =  LbFontCharSprite(lbFontPtr, my_char_to_upper(*str));
             LbSpriteDrawOneColour(pos_x + 1, pos_y + 1, p_spr, colour_lookup[ColLU_BLACK]);
             LbSpriteDrawOneColour(pos_x, pos_y,  p_spr, pixmap.fade_table[fade_lv * PALETTE_8b_COLORS + col2]);
@@ -196,7 +197,7 @@ TbBool AppTextDrawMissionStatus(int posx, int posy, const char *text)
     lbDisplay.ShadowColour = colour_lookup[ColLU_BLACK];
 #endif
 #if 0 // old way of drawing mission status - remove pending
-    if (render_anim_turn & 0x40) {
+    if ((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x40) {
     if (units_per_px < 24)
         draw_text_linewrap2b(posx, &posy, text);
     else
@@ -335,7 +336,7 @@ TbBool AppTextDrawMissionChatMessage(int posx, int *posy, int plyr, int timer,
     lbDisplay.ShadowColour = colour_lookup[ColLU_GREYLT];
 #endif
 #if 0 // old way of drawing mission status - remove pending
-    if (render_anim_turn & 0x20) {
+    if ((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x20) {
     if (units_per_px < 24)
         draw_text_linewrap2(posx, posy, plyr, text);
     else

--- a/src/game.c
+++ b/src/game.c
@@ -1574,7 +1574,7 @@ void init_outro(void)
     outro_unkn02 = 0;
     outro_unkn03 = 0;
     gameturn = 0;
-    render_anim_turn = gameturn;
+    render_clock_set_turn(gameturn);
 
     screen_animate_draw_outro_text();
     // Sleep for up to 10 seconds
@@ -1618,7 +1618,7 @@ void init_outro(void)
         }
 
         gameturn++;
-        render_anim_turn = gameturn;
+        render_clock_set_turn(gameturn);
         traffic_unkn_func_01();
         camera_apply_velocity();
         prepare_drawlist();
@@ -5699,7 +5699,7 @@ void show_load_and_prep_mission(void)
         }
         debug_trace_place(19);
     }
-    render_anim_turn = gameturn;
+    render_clock_set_turn(gameturn);
 
     // Set up remaining graphics data and controls
     if (start_into_mission)
@@ -6163,8 +6163,7 @@ void draw_game(void)
 {
     // One more frame is about to be drawn. The counters the drawing uses
     // advance here, so that they follow the frames and not the game turns.
-    drawturn++;
-    render_anim_turn++;
+    render_clock_next_frame(RENDER_ANIM_TURN_UNIT);
 
     switch (ingame.DisplayMode)
     {

--- a/src/game_speed.c
+++ b/src/game_speed.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include "bfkeybd.h"
 #include "bftime.h"
+#include "enginprops.h"
 #include "game.h"
 #include "keyboard.h"
 #include "swlog.h"
@@ -37,6 +38,17 @@ ushort game_num_fps = 16;
 ushort fifties_per_gameturn = 3;
 
 /******************************************************************************/
+
+void render_clock_set_turn(ulong turn)
+{
+    render_anim_turn = (u32)turn << RENDER_ANIM_TURN_SHIFT;
+}
+
+void render_clock_next_frame(u32 anim_turn_incr)
+{
+    drawturn++;
+    render_anim_turn += anim_turn_incr;
+}
 
 void frameskip_clip(void)
 {

--- a/src/game_speed.h
+++ b/src/game_speed.h
@@ -49,6 +49,22 @@ extern ushort fifties_per_gameturn;
  * turns per second. */
 extern ushort game_num_fps;
 
+/** Opens a drawn frame: advances drawturn, and moves the animation clock on
+ * by the given amount.
+ *
+ * The amount is in the units of render_anim_turn, so RENDER_ANIM_TURN_UNIT is
+ * one animation turn - the pace the game has always drawn at, one animation
+ * frame per game turn. Smaller amounts spread an animation frame over several
+ * drawn frames, larger ones run animations faster, and zero opens a frame
+ * which shows the animations exactly where the previous one left them.
+ */
+void render_clock_next_frame(u32 anim_turn_incr);
+
+/** Places the animation clock on the given animation turn, on a mission or
+ * the outro starting.
+ */
+void render_clock_set_turn(ulong turn);
+
 /**
  * Handles game speed control inputs.
  * @return Returns true if packet was created, false otherwise.

--- a/src/hud_panel.c
+++ b/src/hud_panel.c
@@ -1655,8 +1655,8 @@ void draw_transparent_slant_bar(short x, short y, ushort w, ushort h)
     point3.pp.X = (x - sh_x);
 
     // The shield bar is animated, even if it's not possible to see
-    waftx = waft_table[(render_anim_turn >> 3) & 31];
-    wafty = waft_table[(render_anim_turn + 16) & 31];
+    waftx = waft_table[(render_anim_turn >> (RENDER_ANIM_TURN_SHIFT + 3)) & 31];
+    wafty = waft_table[((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + 16) & 31];
     tmx = ((waftx + 30) >> 1);
     tmy = ((wafty + 30) >> 3) + 64;
     point1.pp.U = tmx << 16;

--- a/src/lvdraw3d.c
+++ b/src/lvdraw3d.c
@@ -77,6 +77,20 @@ extern short word_19CC66;
 TbBool nuclear_overexposure = false;
 
 
+/** Height of the wobbly surface at the given map spot on the given animation
+ * turn.
+ *
+ * Pulled out of shpoint_compute_coord_y() so that the surface can be asked
+ * for the turn being drawn and for the one after it, and placed in between
+ * when a game turn is drawn in more than one frame.
+ */
+static int floor_wobble_at_turn(int elcr_x, int elcr_z, int dvfactor, uint anim_turn)
+{
+    return (waft_table2[(anim_turn + (elcr_x >> 7)) & 0x1F]
+         + waft_table2[(anim_turn + (elcr_z >> 7)) & 0x1F]
+         + waft_table2[(32 * anim_turn / dvfactor) & 0x1F]) >> 3;
+}
+
 int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_mapel, int elcr_x, int elcr_z, int mag)
 {
     int elcr_y;
@@ -90,20 +104,26 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
     {
         elcr_y = 8 * p_mapel->Alt;
         if ((p_mapel->Flags & 0x40) != 0)
-            elcr_y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
+            elcr_y += waft_between_turns(render_anim_turn);
         p_sp->ReflShade = 0;
     }
     else
     {
         int wobble, dvfactor;
-        uint anim_turn;
+        uint anim_turn, within_turn;
 
         elcr_y = 8 * p_mapel->Alt;
         dvfactor = 140 + ((bw_rotl32(0x5D3BA6C3, elcr_z >> 8) ^ bw_rotr32(0xA7B4D8AC, elcr_x >> 8)) & 0x7F);
         anim_turn = render_anim_turn >> RENDER_ANIM_TURN_SHIFT;
-        wobble = (waft_table2[(anim_turn + (elcr_x >> 7)) & 0x1F]
-             + waft_table2[(anim_turn + (elcr_z >> 7)) & 0x1F]
-             + waft_table2[(32 * anim_turn / dvfactor) & 0x1F]) >> 3;
+        within_turn = render_anim_turn & (RENDER_ANIM_TURN_UNIT - 1);
+        wobble = floor_wobble_at_turn(elcr_x, elcr_z, dvfactor, anim_turn);
+        if (within_turn != 0)
+        {
+            int wobble_next;
+
+            wobble_next = floor_wobble_at_turn(elcr_x, elcr_z, dvfactor, anim_turn + 1);
+            wobble += ((wobble_next - wobble) * (int)within_turn) / RENDER_ANIM_TURN_UNIT;
+        }
         elcr_y += mag * wobble;
         p_sp->ReflShade = (wobble + 32) << 9;
     }

--- a/src/lvdraw3d.c
+++ b/src/lvdraw3d.c
@@ -90,18 +90,20 @@ int shpoint_compute_coord_y(struct ShEnginePoint *p_sp, struct MyMapElement *p_m
     {
         elcr_y = 8 * p_mapel->Alt;
         if ((p_mapel->Flags & 0x40) != 0)
-            elcr_y += waft_table[render_anim_turn & 0x1F];
+            elcr_y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
         p_sp->ReflShade = 0;
     }
     else
     {
         int wobble, dvfactor;
+        uint anim_turn;
 
         elcr_y = 8 * p_mapel->Alt;
         dvfactor = 140 + ((bw_rotl32(0x5D3BA6C3, elcr_z >> 8) ^ bw_rotr32(0xA7B4D8AC, elcr_x >> 8)) & 0x7F);
-        wobble = (waft_table2[(render_anim_turn + (elcr_x >> 7)) & 0x1F]
-             + waft_table2[(render_anim_turn + (elcr_z >> 7)) & 0x1F]
-             + waft_table2[(32 * render_anim_turn / dvfactor) & 0x1F]) >> 3;
+        anim_turn = render_anim_turn >> RENDER_ANIM_TURN_SHIFT;
+        wobble = (waft_table2[(anim_turn + (elcr_x >> 7)) & 0x1F]
+             + waft_table2[(anim_turn + (elcr_z >> 7)) & 0x1F]
+             + waft_table2[(32 * anim_turn / dvfactor) & 0x1F]) >> 3;
         elcr_y += mag * wobble;
         p_sp->ReflShade = (wobble + 32) << 9;
     }

--- a/swrendersoft/include/enginpeff.h
+++ b/swrendersoft/include/enginpeff.h
@@ -21,6 +21,8 @@
 
 #include "bftypes.h"
 
+#include "enginprops.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,6 +69,33 @@ extern const short waft_table2[32];
  * The period of this table is 32, last element repeats first.
  */
 extern const short waft_table[33];
+
+/** Value of waft_table at the point of the animation turn the clock stands on.
+ *
+ * Everything which bobs on a wobbly terrain map moves by one table entry per
+ * animation turn. Reading the entry of the turn alone leaves it still until
+ * the turn ends, then jumps it, as soon as a turn is drawn in more than one
+ * frame; this places it where it belongs for the frame instead. While the
+ * clock sits exactly on a turn - which is where it always is when a turn is
+ * drawn in one frame - the value and the work are those of the plain lookup.
+ *
+ * Inline on purpose: its callers sit next to inline assembly, and a call
+ * there would move registers around for no gain.
+ */
+static inline int waft_between_turns(u32 anim_clock)
+{
+    uint anim_turn, within_turn;
+    int v0, v1;
+
+    anim_turn = anim_clock >> RENDER_ANIM_TURN_SHIFT;
+    within_turn = anim_clock & (RENDER_ANIM_TURN_UNIT - 1);
+
+    v0 = waft_table[anim_turn & 0x1F];
+    if (within_turn == 0)
+        return v0;
+    v1 = waft_table[(anim_turn + 1) & 0x1F];
+    return v0 + ((v1 - v0) * (int)within_turn) / RENDER_ANIM_TURN_UNIT;
+}
 
 void scene_post_effect_prepare(void);
 void scene_post_effect_for_bucket(short bckt);

--- a/swrendersoft/include/enginprops.h
+++ b/swrendersoft/include/enginprops.h
@@ -40,6 +40,15 @@ enum RenderFacesFlags {
 
 #pragma pack()
 /******************************************************************************/
+/** Amount of low bits of render_anim_turn which hold the position within
+ * the current animation turn.
+ */
+#define RENDER_ANIM_TURN_SHIFT 8
+
+/** Amount by which render_anim_turn advances over one animation turn.
+ */
+#define RENDER_ANIM_TURN_UNIT (1 << RENDER_ANIM_TURN_SHIFT)
+
 /** Animation turn for the animations controlled within the render engine.
  *
  * Animations which are independent of game action, like moving colours
@@ -48,10 +57,17 @@ enum RenderFacesFlags {
  * Such animations use this value as a measure of progressing time, and
  * therefore progressing animation frames.
  *
- * The value is expected to be incremented once per drawn frame within the
- * game code. It is deliberately not tied to game turns: nothing in the
- * simulation reads it, and an animation which does not touch the game world
- * has no reason to wait for one.
+ * The value is expected to be advanced once per drawn frame within the game
+ * code. It is deliberately not tied to game turns: nothing in the simulation
+ * reads it, and an animation which does not touch the game world has no
+ * reason to wait for one.
+ *
+ * It is a fixed point value: one animation turn is RENDER_ANIM_TURN_UNIT,
+ * and the low RENDER_ANIM_TURN_SHIFT bits hold the position within the turn.
+ * An animation which steps once per animation turn therefore reads
+ * `render_anim_turn >> RENDER_ANIM_TURN_SHIFT`, and one which is to step at
+ * half that speed shifts by one more bit; the fraction is there for anything
+ * which can place itself in between two steps.
  */
 extern u32 render_anim_turn;
 

--- a/swrendersoft/src/app_text_cw.c
+++ b/swrendersoft/src/app_text_cw.c
@@ -211,10 +211,12 @@ void put_down_cw_sprites(const char *sbuf, const char *ebuf,
 {
     if (units_per_px == 16)
     {
-        put_down_colwavetext_sprites(sbuf, ebuf, x, y, space_len, 32, 16, render_anim_turn);
+        put_down_colwavetext_sprites(sbuf, ebuf, x, y, space_len, 32, 16,
+          render_anim_turn >> RENDER_ANIM_TURN_SHIFT);
     } else
     {
-        put_down_colwavetext_sprites_resized(sbuf, ebuf, x, y, space_len, units_per_px, 32, 16, render_anim_turn);
+        put_down_colwavetext_sprites_resized(sbuf, ebuf, x, y, space_len, units_per_px, 32, 16,
+          render_anim_turn >> RENDER_ANIM_TURN_SHIFT);
     }
 }
 

--- a/swrendersoft/src/engindrwlstm_3d.c
+++ b/swrendersoft/src/engindrwlstm_3d.c
@@ -117,7 +117,7 @@ void enlist_draw_frame_graphic(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -145,7 +145,7 @@ void enlist_draw_frame_graphic_scale(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -262,7 +262,7 @@ void enlist_draw_fire_flames(ushort flame_beg)
         cor_dz = p_flame->z - engn_zc;
 
         if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-            cor_dy += waft_table[render_anim_turn & 0x1F];
+            cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
 
         transform_shpoint(&sp, cor_dx, cor_dy - 8 * engn_yc, cor_dz);
 
@@ -413,7 +413,7 @@ void enlist_draw_number(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -441,7 +441,7 @@ void enlist_draw_text(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[render_anim_turn & 0x1F] >> 3;
+        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -818,9 +818,9 @@ void enlist_draw_wobble_line(int x1, int y1, int z1,
         }
         else if (step == 1)
         {
-            shift = ((zig_zag[(render_anim_turn + x1) & 0x1F] & 7) << 7) - 512;
+            shift = ((zig_zag[((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + x1) & 0x1F] & 7) << 7) - 512;
             prc_cur_x1 = prc_cur_x2 + ((shift * overall_scale) >> 8);
-            shift = ((zig_zag[(render_anim_turn + y1) & 0x1F] & 7) << 7) - 512;
+            shift = ((zig_zag[((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + y1) & 0x1F] & 7) << 7) - 512;
             prc_cur_y1 = prc_cur_y2 + ((shift * overall_scale) >> 8);
             shift = ((LbRandomPosShort() & 7) << 7) - 512;
             prc_cur_x2 = prc_x1 + ((shift * overall_scale) >> 8);
@@ -829,9 +829,9 @@ void enlist_draw_wobble_line(int x1, int y1, int z1,
         }
         else if (step == num_steps)
         {
-            shift = ((zig_zag[(render_anim_turn + x2) & 0x1F] & 7) << 7) - 512;
+            shift = ((zig_zag[((render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + x2) & 0x1F] & 7) << 7) - 512;
             prc_cur_x2 = prc_x1 + ((shift * overall_scale) >> 8);
-            shift = ((zig_zag[(y2 + render_anim_turn) & 0x1F] & 7) << 7) - 512;
+            shift = ((zig_zag[(y2 + (render_anim_turn >> RENDER_ANIM_TURN_SHIFT)) & 0x1F] & 7) << 7) - 512;
             prc_cur_y2 = prc_y1 + ((shift * overall_scale) >> 8);
         }
 

--- a/swrendersoft/src/engindrwlstm_3d.c
+++ b/swrendersoft/src/engindrwlstm_3d.c
@@ -117,7 +117,7 @@ void enlist_draw_frame_graphic(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -145,7 +145,7 @@ void enlist_draw_frame_graphic_scale(int x, int y, int z, ushort frame,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -262,7 +262,7 @@ void enlist_draw_fire_flames(ushort flame_beg)
         cor_dz = p_flame->z - engn_zc;
 
         if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-            cor_dy += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F];
+            cor_dy += waft_between_turns(render_anim_turn);
 
         transform_shpoint(&sp, cor_dx, cor_dy - 8 * engn_yc, cor_dz);
 
@@ -413,7 +413,7 @@ void enlist_draw_number(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 
@@ -441,7 +441,7 @@ void enlist_draw_text(int x, int y, int z, short scr_dx, short scr_dy,
     int scr_depth;
 
     if ((render_floor_flags & RendFlrF_WobblyTerrain) != 0)
-        y += waft_table[(render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x1F] >> 3;
+        y += waft_between_turns(render_anim_turn) >> 3;
 
     transform_shpoint(&sp, x, 8 * y - 8 * engn_yc, z);
 

--- a/swrendersoft/src/engindrwlstx_fac.c
+++ b/swrendersoft/src/engindrwlstx_fac.c
@@ -441,7 +441,7 @@ void draw_object_face4g_textrd(ushort face4)
     {
         if ((p_face4->GFlags & (FGFlg_Unkn40|FGFlg_Unkn02)) != 0) {
             uint frame;
-            frame = render_anim_turn + 4 * p_face4->Object;
+            frame = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + 4 * p_face4->Object;
             if ((frame & 0x0F) <= 7) {
                 vec_mode = 2;
             } else {
@@ -837,7 +837,7 @@ void draw_object_face3g_textrd(ushort face3)
     {
         if ((p_face->GFlags & FGFlg_Unkn40) != 0) {
             uint frame;
-            frame = render_anim_turn + p_face->Object;
+            frame = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + p_face->Object;
             if ((frame & 0x1F) > 0x10)
                 vec_mode = 5;
         }
@@ -1439,7 +1439,7 @@ void draw_object_face3d_textrd(ushort face3)
     {
         if ((p_face->GFlags & FGFlg_Unkn40) != 0) {
             uint frame;
-            frame = render_anim_turn + p_face->Object;
+            frame = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + p_face->Object;
             if ((frame & 0x1FF) > 0x100 && !byte_153014[frame & 0x3F])
                 vec_mode = 5;
         }
@@ -1598,7 +1598,7 @@ void draw_object_face4d_textrd(ushort face4)
     {
         if ((p_face4->GFlags & FGFlg_Unkn40) != 0) {
             uint frame;
-            frame = render_anim_turn + p_face4->Object;
+            frame = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) + p_face4->Object;
             if ((frame & 0x1FF) > 0x100 && !byte_153014[frame & 0x3F])
                 vec_mode = 5;
         }

--- a/swrendersoft/src/enginpeff.c
+++ b/swrendersoft/src/enginpeff.c
@@ -77,7 +77,7 @@ void scene_post_effect_rain_init(void)
             ushort idx1, idx2;
             ubyte *tmap;
 
-            rnd = (render_anim_turn >> 2) + LbRandomAnyShort();
+            rnd = (render_anim_turn >> (RENDER_ANIM_TURN_SHIFT + 2)) + LbRandomAnyShort();
             idx1 = (rnd >> 3) & 0x1FFF;
             if ((byte_1A7EE8[idx1] & (1 << (idx1 & 7))) == 0)
             {
@@ -112,7 +112,7 @@ void water_droplets_on_floor(void)
             }
             n = k >> 3;
             byte_1A7EE8[n] &= ~(1 << (n & 7));
-            k = (render_anim_turn >> 2) + LbRandomAnyShort();
+            k = (render_anim_turn >> (RENDER_ANIM_TURN_SHIFT + 2)) + LbRandomAnyShort();
             n = k >> 3;
             if (((1 << (n & 7)) & byte_1A7EE8[n]) == 0)
             {
@@ -151,7 +151,7 @@ void scene_post_effect_texture_with_snow(void)
     for (i = 0; i < 10; i++) {
         ushort pos;
         ubyte *ptr;
-        pos = LbRandomAnyShort() + (render_anim_turn >> 2);
+        pos = LbRandomAnyShort() + (render_anim_turn >> (RENDER_ANIM_TURN_SHIFT + 2));
         ptr = vec_tmap[0] + pos;
         *ptr = pixmap.fade_table[40*PALETTE_8b_COLORS + *ptr];
     }
@@ -207,7 +207,7 @@ void draw_falling_rain(int bckt)
     scanln = lbDisplay.GraphicsScreenWidth;
 
     icol = (BUCKETS_COUNT - bckt) / 416 << 7;
-    shift_y = render_anim_turn * (BUCKETS_COUNT - bckt);
+    shift_y = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) * (BUCKETS_COUNT - bckt);
     limit_y = 236 - (bckt >> 5);
     if (limit_y < 20)
         return;
@@ -271,10 +271,10 @@ void draw_falling_snow(int bckt)
 
         lbSeed = bckt;
         speed = (bckt >> 5) & 0x3;
-        shift1 = waft_table[(bckt + render_anim_turn) & 0x1F];
+        shift1 = waft_table[(bckt + (render_anim_turn >> RENDER_ANIM_TURN_SHIFT)) & 0x1F];
         // Moving with full background speed would be >> 19, dividing by half to make rotation look beter
         x = (shift1 >> (speed + 1)) + ((engn_zc * lbSinTable[angXZs]) >> 20) - ((engn_xc * lbSinTable[angXZc]) >> 20) + LbRandomAnyShort();
-        shift2 = (BUCKETS_COUNT - bckt) * render_anim_turn;
+        shift2 = (BUCKETS_COUNT - bckt) * (render_anim_turn >> RENDER_ANIM_TURN_SHIFT);
         y = (shift2 >> (12 - speed/2)) + ((engn_xc * lbSinTable[angXZs]) >> 20) + ((engn_zc * lbSinTable[angXZc]) >> 20) + LbRandomAnyShort();
         lbDisplay.DrawFlags = Lb_SPRITE_TRANSPAR4;
         dm = size_limited(m, snow_flake_max_size);
@@ -341,7 +341,7 @@ void draw_background_stars(void)
         int simp_x, simp_y;
         int scr_x, scr_y;
 
-        gt = render_anim_turn & 0x7FF;
+        gt = (render_anim_turn >> RENDER_ANIM_TURN_SHIFT) & 0x7FF;
         plane = (i >> 4) + 1;
 #if 0 // some testing code which remained for no reason, remove later
         if (lbShift == KMod_SHIFT)


### PR DESCRIPTION
Shaved off #422, as you suggested, and reworked on today's master after your
comments on the shape of it. Two commits, and nothing on screen changes with
either: the game still draws one frame per game turn, and every value read is
the one it read before.

**The clock.** `render_anim_turn` was incremented once per drawn frame and
assigned in three other places. It now goes through `render_clock_set_turn()`
and `render_clock_next_frame()`, and it becomes a fixed point value:
`RENDER_ANIM_TURN_UNIT` (256) is one animation turn, and the low
`RENDER_ANIM_TURN_SHIFT` (8) bits hold the position within that turn.
Everything which steps once per animation turn shifts the clock down by that
much, and the readers which already wanted a slower animation spend a bit or
two more on the same shift.

`render_clock_next_frame()` takes the amount to move the clock on by, so a
frame is free to advance the animations by any share of a turn - none of it,
part of it, or more than one turn at a time. The single call site here asks
for one whole turn, so every reader sees the value it always saw.

**The surfaces.** Everything bobbing on a wobbly terrain map steps by one
`waft_table` entry per animation turn, which is right as long as the clock
lands on a turn every frame. `waft_between_turns()` gives the value at the
point of the turn the clock stands on, and the floor lookup in
`shpoint_compute_coord_y()` is pulled out as `floor_wobble_at_turn()` so it
can be asked for the turn being drawn and for the one after it. Both leave
early while the clock sits exactly on a turn, so today they cost what the
plain table lookup cost - the second lookup is never reached.

`camera_update_angle_derived()` is not here: you said you would divide that
function yourself, and I see you have. The camera position saving is not here
either, since you would rather have something reusable. What is left of #422
after this is the frame loop itself, the config key, and the camera and thing
interpolation; I will rebuild it on your tree once your camera work has
settled.

Built at `-O2` on Linux, run headless through a mission with a quiet log, and
tried in game on the first mission and on 34 - the map over the water, since
the wobbly surfaces are where this would show if anywhere. Nothing looked
different to me.
